### PR TITLE
Improve documentation for mkdocs site generation

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,1472 @@
+# NOTICE.md
+
+This software is distributed under the Apache Software License (ASL) v2.0, see LICENSE file or <http://www.apache.org/licenses/LICENSE-2.0> for details.
+
+- Please be advised that:
+  - The Grafana and Loki software are used with the AGPL License.
+  - The Ansible and Wazuh software are used with the GPL License.
+
+Below are all the FOSS (Free and open-source software) used and their respective licenses:
+
+- Cert manager :
+  - Helm chart
+    - Version: v1.13.3
+    - License: [Apache License 2.0](https://github.com/cert-manager/cert-manager/blob/v1.13.3/LICENSE)
+    - Source: <https://github.com/cert-manager/cert-manager/tree/v1.13.3/deploy/charts/cert-manager>
+    - Copyright: Copyright The cert-manager Authors. [Authors and Contributors](https://github.com/cert-manager/cert-manager/blob/v1.6.1/deploy/charts/cert-manager/OWNERS)
+  - Container image(s)
+    - quay.io/jetstack/cert-manager-cainjector:v1.13.3
+      - License: [Apache License 2.0](https://github.com/cert-manager/cert-manager/blob/v1.13.3/LICENSE)
+
+- NGINX Ingress Controller :
+  - Helm chart
+    - Version: v4.9.1
+    - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.9.1/LICENSE)
+    - Source: <https://github.com/kubernetes/ingress-nginx/tree/helm-chart-4.9.1/charts/ingress-nginx>
+    - Copyright: Copyright The ingress-nginx Authors. Authors and Contributors [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.9.1/OWNERS) and [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.9.1/OWNERS_ALIASES)
+  - Container image(s)
+    - registry.k8s.io/ingress-nginx/controller:v1.9.6
+      - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/controller-v1.9.6/LICENSE)
+    - docker.io/library/nginx:1.25.2-alpine
+      - License: [BSD 2-Clause "Simplified" License](https://github.com/nginxinc/docker-nginx/blob/1.25.2/LICENSE)
+  
+- Grafana Operator
+  - Helm chart: *None*
+    - Version: 1.1.0
+    - License: [Apache License 2.0](https://github.com/COPRS/infrastructure/blob/1.1.0-rc3/LICENSE)
+    - Copyright: Copyright the Grafana Authors. [Authors and Contributors](https://github.com/grafana/grafana/graphs/contributors)
+  - Container image(s)
+    - ghcr.io/grafana/grafana-operator:v5.9.0
+      - License: [Apache License 2.0](https://github.com/grafana/grafana-operator/blob/v5.9.0/LICENSE)
+    - grafana/grafana:10.0.3
+      - License: [GNU Affero General Public License v3.0](https://github.com/grafana/grafana/blob/v10.0.3/LICENSE)
+
+- PostgreSQL
+  - Helm chart:
+    - Version: 0.20.1
+    - Licence: [Apache License 2.0](https://github.com/cloudnative-pg/charts/blob/cloudnative-pg-v0.20.1/LICENSE)
+    - Source: <https://github.com/cloudnative-pg/charts/tree/cloudnative-pg-v0.20.1>
+    - Copyright: Copyright The CloudNativePG authors. [Authors and Contributors](https://github.com/cloudnative-pg/charts/graphs/contributors)
+  - Container image(s)
+    - ghcr.io/cloudnative-pg/cloudnative-pg:1.22.1
+      - License: [Apache License 2.0](https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.22.1/LICENSE)
+    - ghcr.io/cloudnative-pg/postgresql:16.1
+      - License: [Apache License 2.0](https://github.com/cloudnative-pg/postgres-containers/blob/main/LICENSE)
+
+- Loki
+  - Helm chart:
+    - Version: 0.79.0
+    - Licence: [Apache License 2.0](https://github.com/grafana/helm-charts/blob/loki-distributed-0.79.0/LICENSE)
+    - Source: <https://github.com/grafana/helm-charts/tree/loki-distributed-0.79.0/charts/loki-distributed>
+    - Copyright: Copyright The Loki Authors. [Authors and Contributors](https://github.com/grafana/helm-charts/graphs/contributors)
+  - Container image(s)
+    - docker.io/grafana/loki:2.9.6
+      - License: [GNU Affero General Public License v3.0](https://github.com/grafana/loki/blob/v2.9.6/LICENSE)
+
+- Keycloak
+  - Helm chart: *None*
+  - Container image(s)
+    - quay.io/keycloak/keycloak:23.0.6
+      - License: [Apache License 2.0](https://github.com/keycloak/keycloak/blob/23.0.6/LICENSE.txt)
+    - quay.io/keycloak/keycloak-operator:23.0.6
+      - License: [Apache License 2.0](https://github.com/keycloak/keycloak/blob/23.0.6/LICENSE.txt)
+
+- CoreDNS
+  - Helm chart: *None*
+  - Container image(s)
+    - registry.k8s.io/coredns/coredns:v1.10.1
+      - License: [Apache License 2.0](https://github.com/coredns/coredns/blob/v1.10.1/LICENSE)
+
+- Kubernetes
+  - Helm chart: *None*
+  - Container image(s): *None*
+  - Version: v1.27.7
+  - License: [Apache License 2.0](https://github.com/kubernetes/kubernetes/blob/v1.27.7/LICENSE)
+
+- Wazuh
+  - Helm chart: *None*
+  - Container image(s): *None*
+  - Version: 4.7.2
+  - License: [GNU General Public License v2.0](https://github.com/wazuh/wazuh/blob/v4.7.2/LICENSE)
+  
+- Containerd
+  - Helm chart: *None*
+  - Container image(s): *None*
+  - Version: 1.4.9-1
+  - License: [Apache License 2.0](https://github.com/containerd/containerd/blob/v1.4.9/LICENSE)
+
+- Jupyter
+  - Helm chart:
+    - Version: 3.3.6
+    - Licence: [Apache License 2.0](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/3.3.6/LICENSE)
+    - Source: <https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tree/3.3.6>
+    - Copyright: Copyright (c) Jupyter Development Team. [Authors and Contributors](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/graphs/contributors)
+  - Container image(s)
+    - ghcr.io/rs-python/rs-infrastructure-jupyter:latest
+      - License: [Apache License 2.0](https://github.com/RS-PYTHON/rs-infrastructure/blob/develop/LICENSE)
+    - quay.io/jupyterhub/k8s-image-awaiter:3.3.6
+      - Licence: [Apache License 2.0](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/3.3.6/LICENSE)
+    - quay.io/jupyterhub/k8s-hub:3.3.6
+      - Licence: [Apache License 2.0](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/3.3.6/LICENSE)
+
+- Neuvector
+  - Helm chart:
+    - Version: 2.7.3
+    - Licence: [Apache License 2.0](https://github.com/neuvector/neuvector-helm/blob/2.7.3/LICENSE)
+    - Source: <https://github.com/neuvector/neuvector-helm/tree/2.7.3>
+    - Copyright: Copyright The Neuvector Development Team. [Authors and Contributors](https://github.com/neuvector/neuvector-helm/graphs/contributors)
+  - Container image(s)
+    - docker.io/neuvector/scanner:latest
+      - License: [Apache License 2.0](https://github.com/neuvector/scanner/blob/main/LICENSE)
+    - docker.io/neuvector/enforcer:5.3.2
+      - Licence: [Apache License 2.0](https://github.com/neuvector/manager/blob/v5.3.2/LICENSE)
+    - docker.io/neuvector/manager:5.3.2
+      - Licence: [Apache License 2.0](https://github.com/neuvector/manager/blob/v5.3.2/LICENSE)
+    - docker.io/neuvector/prometheus-exporter:latest
+      - Licence: [Apache License 2.0](https://github.com/neuvector/prometheus-exporter/blob/master/LICENSE)
+
+- oauth2-proxy
+  - Helm chart:
+    - Version: 7.1.0
+    - Licence: [Apache License 2.0](https://github.com/oauth2-proxy/manifests/blob/oauth2-proxy-7.1.0/LICENSE)
+    - Source: <https://github.com/oauth2-proxy/manifests/tree/oauth2-proxy-7.1.0>
+    - Copyright: Copyright The oauth2-proxy Development Team. [Authors and Contributors](https://github.com/oauth2-proxy/manifests/graphs/contributors)
+  - Container image(s)
+    - quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+      - License: [MIT License](https://github.com/oauth2-proxy/oauth2-proxy/blob/v7.6.0/LICENSE)
+
+- Prefect
+  - Helm chart:
+    - Version: 7.1.0
+    - Licence: [Apache License 2.0](https://github.com/PrefectHQ/prefect-helm/blob/2024.5.2224951/LICENSE)
+    - Source: <https://github.com/PrefectHQ/prefect-helm/tree/2024.5.2224951>
+    - Copyright: Copyright The Prefect Development Team. [Authors and Contributors](https://github.com/PrefectHQ/prefect-helm/graphs/contributors)
+  - Container image(s)
+    - prefecthq/prefect:2.18.1-python3.11-kubernetes
+      - License: [Apache License 2.0](https://github.com/PrefectHQ/prefect/blob/2.18.1/LICENSE)
+    - prefecthq/prefect:2.18.3-python3.11-kubernetes
+      - License: [Apache License 2.0](https://github.com/PrefectHQ/prefect/blob/2.18.3/LICENSE)
+
+- kube-prometheus-stack
+  - Helm chart:
+    - Version: 58.0.0
+    - Licence: [Apache License 2.0](https://github.com/prometheus-community/helm-charts/blob/kube-prometheus-stack-58.0.0/LICENSE)
+    - Source: <https://github.com/prometheus-community/helm-charts/tree/kube-prometheus-stack-58.0.0>
+    - Copyright: Copyright The Prometheus community Development Team. [Authors and Contributors](https://github.com/prometheus-community/helm-charts/graphs/contributors)
+  - Container image(s)
+    - quay.io/prometheus-operator/prometheus-config-reloader:v0.73.0
+      - License: [Apache License 2.0](https://github.com/prometheus-operator/prometheus-operator/blob/v0.73.0/LICENSE)
+    - quay.io/prometheus/alertmanager:v0.27.0
+      - License: [Apache License 2.0](https://github.com/prometheus/alertmanager/blob/v0.27.0/LICENSE)
+    - quay.io/prometheus-operator/prometheus-operator:v0.73.0
+      - License: [Apache License 2.0](https://github.com/prometheus-operator/prometheus-operator/blob/v0.73.0/LICENSE)
+    - registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+      - License: [Apache License 2.0](https://github.com/kubernetes/kube-state-metrics/blob/v2.12.0/LICENSE)
+    - quay.io/prometheus/prometheus:v2.51.1
+      - License: [Apache License 2.0](https://github.com/prometheus/prometheus/blob/v2.51.1/LICENSE)
+    - quay.io/prometheus/node-exporter:v1.7.0
+      - License: [Apache License 2.0](https://github.com/prometheus/node_exporter/blob/v1.7.0/LICENSE)
+
+- Promtail
+  - Helm chart:
+    - Version: 6.15.5
+    - Licence: [Apache License 2.0](https://github.com/grafana/helm-charts/blob/promtail-6.15.5/LICENSE)
+    - Source: <https://github.com/grafana/helm-charts/tree/promtail-6.15.5/charts/promtail>
+    - Copyright: Copyright The Grafana Development Team. [Authors and Contributors](https://github.com/grafana/helm-charts/graphs/contributors)
+  - Container image(s)
+    - docker.io/grafana/promtail:2.9.3
+      - License: [GNU Affero General Public License v3.0](https://github.com/grafana/loki/blob/v2.9.3/LICENSE)
+
+## Licenses
+
+### Apache License 2.0
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+### GNU Affero General Public License v3.0
+
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.
+
+### GNU General Public License v2.0
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.
+
+### MIT License
+
+MIT License
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+### BSD 2-Clause "Simplified" License
+
+BSD 2-Clause License
+
+Copyright (c) [year], [fullname]
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+### BSD 3-Clause "New" or "Revised" License
+
+BSD 3-Clause License
+
+Copyright (c) [year], [fullname]
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,18 @@
 This repository provides kubernetes infrastructure and security layouts to support rs-server processing chains.
 
 ## Getting started
-Documentation is available in the [docs' folder](./docs).
+Documentation is available in the [docs' folder](./docs/installation.md).
 
 
 <br> <br>
+![](./docs/media/banner_logo.jpg)
+<!---
+Centering the banner logo image is not rendered by the mkdocs inside the rs-documentation repository
+-->
+<!---
 <p align="center">
  <img src="/docs/media/banner_logo.jpg" width="71%" height="71%" />
 </p>
+-->
 <p align="center">This project is funded by the EU and ESA.</p>
 <br> <br>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,125 +1,127 @@
 # Infrastructure - Installation
- ## Overview
+## Overview
 
- ![Infrastructure overview](./media/RSPY_infra_smallres.png)
+![Infrastructure overview](./media/RSPY_infra_smallres.png)
 
- > **Admin's machine is called BASTION in the rest of the installation manual**
- ## _Bastion_ requirements
+> **Admin's machine is called BASTION in the rest of the installation manual**
 
- - miniforge
- - git
- - jq
+## _Bastion_ requirements
 
- ## Dependencies
+- miniforge
+- git
+- jq
 
- ### Terraform
+## Dependencies
 
- This project exploits Terraform to deploy the infrastructure on the Cloud Provider.  
- The fully detailed documentation and configuration options are available on its page: [https://www.terraform.io/](https://www.terraform.io/)
+### Terraform
 
- ### Kubespray
+This project exploits Terraform to deploy the infrastructure on the Cloud Provider.  
+The fully detailed documentation and configuration options are available on its page: [https://www.terraform.io/](https://www.terraform.io/)
 
- This project exploits Kubespray to deploy Kubernetes.  
- The fully detailed documentation and configuration options are available on its page: [https://kubespray.io/](https://kubespray.io/)
+### Kubespray
 
- ### HashiCorp Vault (optional)
+This project exploits Kubespray to deploy Kubernetes.  
+The fully detailed documentation and configuration options are available on its page: [https://kubespray.io/](https://kubespray.io/)
 
- This project can integrate credentials from a custom `HashiCorp Vault` instance, see the specific documentation: [how to/Credentials](./how-to/Credentials.md)
+### HashiCorp Vault (optional)
 
- ### Openstack CLI
+This project can integrate credentials from a custom `HashiCorp Vault` instance, see the specific documentation: [how to/Credentials](./how-to/Credentials.md)
 
- This project exploits Openstack CLI to manage the state of the infrastructure on the Cloud Provider.  
- The fully detailled documentation and configuration options are available on its page: [https://docs.openstack.org/newton/user-guide/cli.html](https://docs.openstack.org/newton/user-guide/cli.html)
+### Openstack CLI
 
- ## Quickstart
+This project exploits Openstack CLI to manage the state of the infrastructure on the Cloud Provider.  
+The fully detailled documentation and configuration options are available on its page: [https://docs.openstack.org/newton/user-guide/cli.html](https://docs.openstack.org/newton/user-guide/cli.html)
 
- ### 1. Get the rs-infrastructure repository
+## Quickstart
 
- ```shellsession
- git clone https://github.com/RS-PYTHON/rs-infrastructure.git
- cd rs-infrastructure
- ```
+### 1. Get the rs-infrastructure repository
 
- ### 2. Install requirements
+```shellsession
+git clone https://github.com/RS-PYTHON/rs-infrastructure.git
+cd rs-infrastructure
+```
 
- ```shellsession
- # Install miniforge
- mkdir -p ~/miniforge3
- wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O ~/miniforge3/miniforge.sh
- bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
- rm -f ~/miniforge3/miniforge.sh
+### 2. Install requirements
 
- # Init conda depending on your shell
- ~/miniforge3/bin/conda init bash
- ~/miniforge3/bin/conda init zsh
+```shellsession
+# Install miniforge
+mkdir -p ~/miniforge3
+wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O ~/miniforge3/miniforge.sh
+bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+rm -f ~/miniforge3/miniforge.sh
 
- # Create conda env with python=3.11 and activate it
- conda create -y -n rspy python=3.11
- conda activate rspy
+# Init conda depending on your shell
+~/miniforge3/bin/conda init bash
+~/miniforge3/bin/conda init zsh
 
- # Install Ansible, Terraform, Openstackclient
- conda install conda-forge::ansible
- conda install conda-forge::terraform
- conda install conda-forge::python-openstackclient
- conda install conda-forge::passlib
+# Create conda env with python=3.11 and activate it
+conda create -y -n rspy python=3.11
+conda activate rspy
 
- # Init Kubespray collection with remote
- git submodule update --init --remote
+# Install Ansible, Terraform, Openstackclient
+conda install conda-forge::ansible
+conda install conda-forge::terraform
+conda install conda-forge::python-openstackclient
+conda install conda-forge::passlib
 
-
- pip install -U pyOpenSSL ecdsa -r collections/kubespray/requirements.txt
-
- ansible-galaxy collection install \
-     kubernetes.core \
-     openstack.cloud
- ```
-
- ### 3. Copy the sample inventory
-
- ```shellsession
- cp -rfp inventory/sample inventory/mycluster
- ```
-
- ### 4. Review and change the default configuration to match your needs
-
- ```shellsession
- cp -rfp roles/terraform/create-cluster/tasks/.env.template roles/terraform/create-cluster/tasks/.env
- ```
-
- Copy the openrc.sh.template into openrc.sh and change the values inside to match your configuration :
-
- ```shellsession
- cp -rfp inventory/mycluster/openrc.sh.template inventory/mycluster/openrc.sh
- ```
-
- - Credentials, domain name, the stash license, S3 endpoints in `inventory/mycluster/host_vars/setup/main.yaml`
- - Credentials in `roles/terraform/create-cluster/tasks/.env`
- - Credentials, domain name in `inventory/mycluster/openrc.sh`
- - Node groups, Network sizing, S3 buckets in `inventory/mycluster/cluster.tfvars`
- - S3 backend for terraform in `inventory/mycluster/backend.tfvars`
- - Optimization for well-known zones and/or internal-only domains, i.e. VPN/Object Storage for internal networks in `inventory/mycluster/group_vars/all/kubespray.yaml`
- - Values for custom parameters in `inventory/mycluster/group_vars/all/apps.yml`
-
- ### 5. Create and configure machines
-
- ```shellsession
- ansible-playbook cluster.yaml \
-     -i inventory/mycluster/hosts.yaml
- ```
+# Init Kubespray collection with remote
+git submodule update --init --remote
 
 
- ### 6. Deploy Kubernetes with `kubespray`
+pip install -U pyOpenSSL ecdsa -r collections/kubespray/requirements.txt
 
- ```shellsession
- ansible-playbook kubernetes.yaml \
-     -i inventory/mycluster/hosts.yaml
- ```
+ansible-galaxy collection install \
+    kubernetes.core \
+    openstack.cloud
+```
+
+### 3. Copy the sample inventory
+
+```shellsession
+cp -rfp inventory/sample inventory/mycluster
+```
+
+### 4. Review and change the default configuration to match your needs
+
+```shellsession
+cp -rfp roles/terraform/create-cluster/tasks/.env.template roles/terraform/create-cluster/tasks/.env
+```
+
+Copy the openrc.sh.template into openrc.sh and change the values inside to match your configuration :
+
+```shellsession
+cp -rfp inventory/mycluster/openrc.sh.template inventory/mycluster/openrc.sh
+```
+
+- Credentials, domain name, the stash license, S3 endpoints in `inventory/mycluster/host_vars/setup/main.yaml`
+- Credentials in `roles/terraform/create-cluster/tasks/.env`
+- Credentials, domain name in `inventory/mycluster/openrc.sh`
+- Node groups, Network sizing, S3 buckets in `inventory/mycluster/cluster.tfvars`
+- S3 backend for terraform in `inventory/mycluster/backend.tfvars`
+- Optimization for well-known zones and/or internal-only domains, i.e. VPN/Object Storage for internal networks in `inventory/mycluster/group_vars/all/kubespray.yaml`
+- Values for custom parameters in `inventory/mycluster/group_vars/all/apps.yml`
+
+### 5. Create and configure machines
+
+```shellsession
+ansible-playbook cluster.yaml \
+    -i inventory/mycluster/hosts.yaml
+```
+
+
+### 6. Deploy Kubernetes with `kubespray`
+
+```shellsession
+ansible-playbook kubernetes.yaml \
+    -i inventory/mycluster/hosts.yaml
+```
 
 ### 7. Deploy the apps
 
 
 !!! warning "Disclaimer : For Wazuh Server installation"
     See **_"1. Enable Bcrypt encryption"_** in the [Wazuh-Server_Install](./how-to/Wazuh-Server_Install.md) and update the `encrypt.py` library before deploy the apps.
+
 
 ```shellsession
 ansible-playbook apps.yaml \

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,145 +1,29 @@
-# Infrastructure - Installation
-## Overview
-
-![Infrastructure overview](./media/RSPY_infra_smallres.png)
-
-> **Admin's machine is called BASTION in the rest of the installation manual**
-
-## _Bastion_ requirements
-
-- miniforge
-- git
-- jq
-
-## Dependencies
-
-### Terraform
-
-This project exploits Terraform to deploy the infrastructure on the Cloud Provider.  
-The fully detailed documentation and configuration options are available on its page: [https://www.terraform.io/](https://www.terraform.io/)
-
-### Kubespray
-
-This project exploits Kubespray to deploy Kubernetes.  
-The fully detailed documentation and configuration options are available on its page: [https://kubespray.io/](https://kubespray.io/)
-
-### HashiCorp Vault (optional)
-
-This project can integrate credentials from a custom `HashiCorp Vault` instance, see the specific documentation: [how to/Credentials](./how-to/Credentials.md)
-
-### Openstack CLI
-
-This project exploits Openstack CLI to manage the state of the infrastructure on the Cloud Provider.  
-The fully detailled documentation and configuration options are available on its page: [https://docs.openstack.org/newton/user-guide/cli.html](https://docs.openstack.org/newton/user-guide/cli.html)
-
-## Quickstart
-
-### 1. Get the rs-infrastructure repository
-
-```shellsession
-git clone https://github.com/RS-PYTHON/rs-infrastructure.git
-cd rs-infrastructure
-```
-
-### 2. Install requirements
-
-```shellsession
-# Install miniforge
-mkdir -p ~/miniforge3
-wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O ~/miniforge3/miniforge.sh
-bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
-rm -f ~/miniforge3/miniforge.sh
-
-# Init conda depending on your shell
-~/miniforge3/bin/conda init bash
-~/miniforge3/bin/conda init zsh
-
-# Create conda env with python=3.11 and activate it
-conda create -y -n rspy python=3.11
-conda activate rspy
-
-# Install Ansible, Terraform, Openstackclient
-conda install conda-forge::ansible
-conda install conda-forge::terraform
-conda install conda-forge::python-openstackclient
-conda install conda-forge::passlib
-
-# Init Kubespray collection with remote
-git submodule update --init --remote
-
-
-pip install -U pyOpenSSL ecdsa -r collections/kubespray/requirements.txt
-
-ansible-galaxy collection install \
-    kubernetes.core \
-    openstack.cloud
-```
-
-### 3. Copy the sample inventory
-
-```shellsession
-cp -rfp inventory/sample inventory/mycluster
-```
-
-### 4. Review and change the default configuration to match your needs
-
-```shellsession
-cp -rfp roles/terraform/create-cluster/tasks/.env.template roles/terraform/create-cluster/tasks/.env
-```
-
-Copy the openrc.sh.template into openrc.sh and change the values inside to match your configuration :
-
-```shellsession
-cp -rfp inventory/mycluster/openrc.sh.template inventory/mycluster/openrc.sh
-```
-
-- Credentials, domain name, the stash license, S3 endpoints in `inventory/mycluster/host_vars/setup/main.yaml`
-- Credentials in `roles/terraform/create-cluster/tasks/.env`
-- Credentials, domain name in `inventory/mycluster/openrc.sh`
-- Node groups, Network sizing, S3 buckets in `inventory/mycluster/cluster.tfvars`
-- S3 backend for terraform in `inventory/mycluster/backend.tfvars`
-- Optimization for well-known zones and/or internal-only domains, i.e. VPN/Object Storage for internal networks in `inventory/mycluster/group_vars/all/kubespray.yaml`
-- Values for custom parameters in `inventory/mycluster/group_vars/all/apps.yml`
-
-### 5. Create and configure machines
-
-```shellsession
-ansible-playbook cluster.yaml \
-    -i inventory/mycluster/hosts.yaml
-```
-
-
-### 6. Deploy Kubernetes with `kubespray`
-
-```shellsession
-ansible-playbook kubernetes.yaml \
-    -i inventory/mycluster/hosts.yaml
-```
-
 ### 7. Deploy the apps
 
 
-> [!CAUTION]
-> Disclaimer : For Wazuh Server installation
-> See **_"1. Enable Bcrypt encryption"_** in the [Wazuh-Server_Install](./how-to/Wazuh-Server_Install.md) and update the `encrypt.py` library before deploy the apps.
-
+!!! warning "Disclaimer : For Wazuh Server installation"
+    See **_"1. Enable Bcrypt encryption"_** in the [Wazuh-Server_Install](./how-to/Wazuh-Server_Install.md) and update the `encrypt.py` library before deploy the apps.
 
 ```shellsession
 ansible-playbook apps.yaml \
     -i inventory/mycluster/hosts.yaml
 ```
-> [!CAUTION]
-> Disclaimer : For Prefect-Worker post-configuration
-> See **_"2. set `Concurrency Limit` on workpool _on-demand-k8s-pool_"_** in the [Prefect-Worker](./how-to/Prefect-Worker.md) after deploy the app.
-
+!!! warning "Disclaimer : For Prefect-Worker post-configuration"
+    See **_"2. set `Concurrency Limit` on workpool _on-demand-k8s-pool_"_** in the [Prefect-Worker](./how-to/Prefect-Worker.md) after deploy the app.
 
 # Copyright and license
 
-The Reference System Software as a whole is distributed under the Apache License, version 2.0. A copy of this license is available in the [LICENSE](LICENSE) file. Reference System Software depends on third-party components and code snippets released under their own license (obviously, all compatible with the one of the Reference System Software). These dependencies are listed in the [NOTICE](NOTICE.md) file.
+The Reference System Software as a whole is distributed under the Apache License, version 2.0. A copy of this license is available in the [LICENSE](/LICENSE) file. Reference System Software depends on third-party components and code snippets released under their own license (obviously, all compatible with the one of the Reference System Software). These dependencies are listed in the [NOTICE](NOTICE.md) file.
 
 <br> <br>
+![](media/banner_logo.jpg)
+<!---
+Centering the banner logo image is not rendered with mkdocs in rs-documentation repository
+-->
+<!---
 <p align="center">
  <img src="/docs/media/banner_logo.jpg" width="71%" height="71%" />
 </p>
+-->
 <p align="center">This project is funded by the EU and ESA.</p>
 <br> <br>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -141,7 +141,7 @@ The Reference System Software as a whole is distributed under the Apache License
 <p align="center">This project is funded by the EU and ESA.</p>
 <br> <br>
 <p align="center">
- <img src="media/banner_logo.jpg" width="71%" height="71%" />
+    ![](media/banner_logo.jpg)
 </p>
 <p align="center">This project is funded by the EU and ESA.</p>
 <br> <br>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -138,7 +138,7 @@ ansible-playbook apps.yaml \
 The Reference System Software as a whole is distributed under the Apache License, version 2.0. A copy of this license is available in the [LICENSE](../LICENSE) file. Reference System Software depends on third-party components and code snippets released under their own license (obviously, all compatible with the one of the Reference System Software). These dependencies are listed in the [NOTICE](NOTICE.md) file.
 
 ![](media/banner_logo.jpg)
-<p style="text-align:center">This project is funded by the EU and ESA.</p>
+<p align="center">This project is funded by the EU and ESA.</p>
 <br> <br>
 <p align="center">
  <img src="../media/banner_logo.jpg" width="71%" height="71%" />

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -141,7 +141,7 @@ The Reference System Software as a whole is distributed under the Apache License
 <p align="center">This project is funded by the EU and ESA.</p>
 <br> <br>
 <p align="center">
-    ![](media/banner_logo.jpg)
+ <img src="../media/banner_logo.jpg" width="71%" height="71%" />
 </p>
 <p align="center">This project is funded by the EU and ESA.</p>
 <br> <br>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -141,7 +141,7 @@ The Reference System Software as a whole is distributed under the Apache License
 <p align="center">This project is funded by the EU and ESA.</p>
 <br> <br>
 <p align="center">
- <img src="../media/banner_logo.jpg" width="71%" height="71%" />
+ <img src="media/banner_logo.jpg" width="71%" height="71%" />
 </p>
 <p align="center">This project is funded by the EU and ESA.</p>
 <br> <br>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -137,5 +137,11 @@ ansible-playbook apps.yaml \
 
 The Reference System Software as a whole is distributed under the Apache License, version 2.0. A copy of this license is available in the [LICENSE](../LICENSE) file. Reference System Software depends on third-party components and code snippets released under their own license (obviously, all compatible with the one of the Reference System Software). These dependencies are listed in the [NOTICE](NOTICE.md) file.
 
-![](media/banner_logo.jpg)  
-This project is funded by the EU and ESA
+![](media/banner_logo.jpg)
+<center>This project is funded by the EU and ESA<center>
+<br> <br>
+<p align="center">
+ <img src="../media/banner_logo.jpg" width="71%" height="71%" />
+</p>
+<p align="center">This project is funded by the EU and ESA.</p>
+<br> <br>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -137,9 +137,5 @@ ansible-playbook apps.yaml \
 
 The Reference System Software as a whole is distributed under the Apache License, version 2.0. A copy of this license is available in the [LICENSE](../LICENSE) file. Reference System Software depends on third-party components and code snippets released under their own license (obviously, all compatible with the one of the Reference System Software). These dependencies are listed in the [NOTICE](NOTICE.md) file.
 
-<br> <br>
-<p align="center">
- <img src="../media/banner_logo.jpg" width="71%" height="71%" />
-</p>
-<p align="center">This project is funded by the EU and ESA.</p>
-<br> <br>
+![](media/banner_logo.jpg)  
+This project is funded by the EU and ESA

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,3 +1,120 @@
+# Infrastructure - Installation
+ ## Overview
+
+ ![Infrastructure overview](./media/RSPY_infra_smallres.png)
+
+ > **Admin's machine is called BASTION in the rest of the installation manual**
+ ## _Bastion_ requirements
+
+ - miniforge
+ - git
+ - jq
+
+ ## Dependencies
+
+ ### Terraform
+
+ This project exploits Terraform to deploy the infrastructure on the Cloud Provider.  
+ The fully detailed documentation and configuration options are available on its page: [https://www.terraform.io/](https://www.terraform.io/)
+
+ ### Kubespray
+
+ This project exploits Kubespray to deploy Kubernetes.  
+ The fully detailed documentation and configuration options are available on its page: [https://kubespray.io/](https://kubespray.io/)
+
+ ### HashiCorp Vault (optional)
+
+ This project can integrate credentials from a custom `HashiCorp Vault` instance, see the specific documentation: [how to/Credentials](./how-to/Credentials.md)
+
+ ### Openstack CLI
+
+ This project exploits Openstack CLI to manage the state of the infrastructure on the Cloud Provider.  
+ The fully detailled documentation and configuration options are available on its page: [https://docs.openstack.org/newton/user-guide/cli.html](https://docs.openstack.org/newton/user-guide/cli.html)
+
+ ## Quickstart
+
+ ### 1. Get the rs-infrastructure repository
+
+ ```shellsession
+ git clone https://github.com/RS-PYTHON/rs-infrastructure.git
+ cd rs-infrastructure
+ ```
+
+ ### 2. Install requirements
+
+ ```shellsession
+ # Install miniforge
+ mkdir -p ~/miniforge3
+ wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O ~/miniforge3/miniforge.sh
+ bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+ rm -f ~/miniforge3/miniforge.sh
+
+ # Init conda depending on your shell
+ ~/miniforge3/bin/conda init bash
+ ~/miniforge3/bin/conda init zsh
+
+ # Create conda env with python=3.11 and activate it
+ conda create -y -n rspy python=3.11
+ conda activate rspy
+
+ # Install Ansible, Terraform, Openstackclient
+ conda install conda-forge::ansible
+ conda install conda-forge::terraform
+ conda install conda-forge::python-openstackclient
+ conda install conda-forge::passlib
+
+ # Init Kubespray collection with remote
+ git submodule update --init --remote
+
+
+ pip install -U pyOpenSSL ecdsa -r collections/kubespray/requirements.txt
+
+ ansible-galaxy collection install \
+     kubernetes.core \
+     openstack.cloud
+ ```
+
+ ### 3. Copy the sample inventory
+
+ ```shellsession
+ cp -rfp inventory/sample inventory/mycluster
+ ```
+
+ ### 4. Review and change the default configuration to match your needs
+
+ ```shellsession
+ cp -rfp roles/terraform/create-cluster/tasks/.env.template roles/terraform/create-cluster/tasks/.env
+ ```
+
+ Copy the openrc.sh.template into openrc.sh and change the values inside to match your configuration :
+
+ ```shellsession
+ cp -rfp inventory/mycluster/openrc.sh.template inventory/mycluster/openrc.sh
+ ```
+
+ - Credentials, domain name, the stash license, S3 endpoints in `inventory/mycluster/host_vars/setup/main.yaml`
+ - Credentials in `roles/terraform/create-cluster/tasks/.env`
+ - Credentials, domain name in `inventory/mycluster/openrc.sh`
+ - Node groups, Network sizing, S3 buckets in `inventory/mycluster/cluster.tfvars`
+ - S3 backend for terraform in `inventory/mycluster/backend.tfvars`
+ - Optimization for well-known zones and/or internal-only domains, i.e. VPN/Object Storage for internal networks in `inventory/mycluster/group_vars/all/kubespray.yaml`
+ - Values for custom parameters in `inventory/mycluster/group_vars/all/apps.yml`
+
+ ### 5. Create and configure machines
+
+ ```shellsession
+ ansible-playbook cluster.yaml \
+     -i inventory/mycluster/hosts.yaml
+ ```
+
+
+ ### 6. Deploy Kubernetes with `kubespray`
+
+ ```shellsession
+ ansible-playbook kubernetes.yaml \
+     -i inventory/mycluster/hosts.yaml
+ ```
+
 ### 7. Deploy the apps
 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -137,11 +137,15 @@ ansible-playbook apps.yaml \
 
 The Reference System Software as a whole is distributed under the Apache License, version 2.0. A copy of this license is available in the [LICENSE](../LICENSE) file. Reference System Software depends on third-party components and code snippets released under their own license (obviously, all compatible with the one of the Reference System Software). These dependencies are listed in the [NOTICE](NOTICE.md) file.
 
-![](media/banner_logo.jpg)
-<p align="center">This project is funded by the EU and ESA.</p>
 <br> <br>
+![](media/banner_logo.jpg)
+<!---
+Centering the banner logo image is not rendered with mkdocs in rs-documentation repository
+-->
+<!---
 <p align="center">
- <img src="../media/banner_logo.jpg" width="71%" height="71%" />
+ <img src="/docs/media/banner_logo.jpg" width="71%" height="71%" />
 </p>
+-->
 <p align="center">This project is funded by the EU and ESA.</p>
 <br> <br>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -135,11 +135,11 @@ ansible-playbook apps.yaml \
 
 # Copyright and license
 
-The Reference System Software as a whole is distributed under the Apache License, version 2.0. A copy of this license is available in the [LICENSE](LICENSE) file. Reference System Software depends on third-party components and code snippets released under their own license (obviously, all compatible with the one of the Reference System Software). These dependencies are listed in the [NOTICE](NOTICE.md) file.
+The Reference System Software as a whole is distributed under the Apache License, version 2.0. A copy of this license is available in the [LICENSE](../LICENSE) file. Reference System Software depends on third-party components and code snippets released under their own license (obviously, all compatible with the one of the Reference System Software). These dependencies are listed in the [NOTICE](NOTICE.md) file.
 
 <br> <br>
 <p align="center">
- <img src="/docs/media/banner_logo.jpg" width="71%" height="71%" />
+ <img src="../media/banner_logo.jpg" width="71%" height="71%" />
 </p>
 <p align="center">This project is funded by the EU and ESA.</p>
 <br> <br>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -138,7 +138,7 @@ ansible-playbook apps.yaml \
 The Reference System Software as a whole is distributed under the Apache License, version 2.0. A copy of this license is available in the [LICENSE](../LICENSE) file. Reference System Software depends on third-party components and code snippets released under their own license (obviously, all compatible with the one of the Reference System Software). These dependencies are listed in the [NOTICE](NOTICE.md) file.
 
 ![](media/banner_logo.jpg)
-<center>This project is funded by the EU and ESA<center>
+<p style="text-align:center">This project is funded by the EU and ESA.</p>
 <br> <br>
 <p align="center">
  <img src="../media/banner_logo.jpg" width="71%" height="71%" />

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -134,7 +134,7 @@ The Reference System Software as a whole is distributed under the Apache License
 <br> <br>
 ![](media/banner_logo.jpg)
 <!---
-Centering the banner logo image is not rendered with mkdocs in rs-documentation repository
+Centering the banner logo image is not rendered by the mkdocs inside the rs-documentation repository
 -->
 <!---
 <p align="center">

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -119,18 +119,16 @@ ansible-playbook kubernetes.yaml \
 ### 7. Deploy the apps
 
 
-> [!CAUTION]
-> Disclaimer : For Wazuh Server installation
-> See **_"1. Enable Bcrypt encryption"_** in the [Wazuh-Server_Install](./how-to/Wazuh-Server_Install.md) and update the `encrypt.py` library before deploy the apps.
+!!! warning "Disclaimer : For Wazuh Server installation"
+    See **_"1. Enable Bcrypt encryption"_** in the [Wazuh-Server_Install](./how-to/Wazuh-Server_Install.md) and update the `encrypt.py` library before deploy the apps.
 
 
 ```shellsession
 ansible-playbook apps.yaml \
     -i inventory/mycluster/hosts.yaml
 ```
-> [!CAUTION]
-> Disclaimer : For Prefect-Worker post-configuration
-> See **_"2. set `Concurrency Limit` on workpool _on-demand-k8s-pool_"_** in the [Prefect-Worker](./how-to/Prefect-Worker.md) after deploy the app.
+!!! warning "Disclaimer : For Prefect-Worker post-configuration"
+    See **_"2. set `Concurrency Limit` on workpool _on-demand-k8s-pool_"_** in the [Prefect-Worker](./how-to/Prefect-Worker.md) after deploy the app.
 
 
 # Copyright and license

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -67,7 +67,6 @@ conda install conda-forge::passlib
 # Init Kubespray collection with remote
 git submodule update --init --remote
 
-
 pip install -U pyOpenSSL ecdsa -r collections/kubespray/requirements.txt
 
 ansible-galaxy collection install \
@@ -108,7 +107,6 @@ ansible-playbook cluster.yaml \
     -i inventory/mycluster/hosts.yaml
 ```
 
-
 ### 6. Deploy Kubernetes with `kubespray`
 
 ```shellsession
@@ -118,22 +116,20 @@ ansible-playbook kubernetes.yaml \
 
 ### 7. Deploy the apps
 
-
 !!! warning "Disclaimer : For Wazuh Server installation"
     See **_"1. Enable Bcrypt encryption"_** in the [Wazuh-Server_Install](./how-to/Wazuh-Server_Install.md) and update the `encrypt.py` library before deploy the apps.
-
 
 ```shellsession
 ansible-playbook apps.yaml \
     -i inventory/mycluster/hosts.yaml
 ```
+
 !!! warning "Disclaimer : For Prefect-Worker post-configuration"
     See **_"2. set `Concurrency Limit` on workpool _on-demand-k8s-pool_"_** in the [Prefect-Worker](./how-to/Prefect-Worker.md) after deploy the app.
 
-
 # Copyright and license
 
-The Reference System Software as a whole is distributed under the Apache License, version 2.0. A copy of this license is available in the [LICENSE](../LICENSE) file. Reference System Software depends on third-party components and code snippets released under their own license (obviously, all compatible with the one of the Reference System Software). These dependencies are listed in the [NOTICE](NOTICE.md) file.
+The Reference System Software as a whole is distributed under the Apache License, version 2.0. A copy of this license is available in the [LICENSE](../LICENSE) file. Reference System Software depends on third-party components and code snippets released under their own license (obviously, all compatible with the one of the Reference System Software). These dependencies are listed in the [NOTICE](../NOTICE.md) file.
 
 <br> <br>
 ![](media/banner_logo.jpg)


### PR DESCRIPTION
- [!CAUTION] is not rendered by the mkdocs. It is accepting the [admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions/) which GitHub does not accept (see the [rendered file](https://github.com/RS-PYTHON/rs-infrastructure/blob/feat-rspy112/improve-documentation/docs/installation.md) in github). A solution would be to use \*\*CAUTION\*\* standard that is accepted by both mkdocs and GitHub
- The second [!CAUTION] block from paragraph 7 seems to link to a wrong name in ./how-to/Prefect-Worker.md file. Paragraph 2 from this file is ```2. Check `Concurrency Limit` on workpool _on-demand-k8s-pool_``` instead of  ```2. set `Concurrency Limit` on workpool _on-demand-k8s-pool_```
- The hack to display the banner logo at the bottom of the file in the center of the page rendered by GitHub does not work for mkdocs, which can't find the path of the file. I switched to a classic image insertion in a markdown file, which probably is not centered anymore in the Github page, but it is displayed in the HTML file generated by mkdocs
- The reference to ```NOTICE.md``` file (in docs/installation.md)  does not exist
-  