### PR TITLE
Update to ingress-nginx 1.12.1

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -20,15 +20,15 @@ Below are all the FOSS (Free and open-source software) used and their respective
 
 - NGINX Ingress Controller :
   - Helm chart
-    - Version: v4.9.1
-    - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.9.1/LICENSE)
-    - Source: <https://github.com/kubernetes/ingress-nginx/tree/helm-chart-4.9.1/charts/ingress-nginx>
-    - Copyright: Copyright The ingress-nginx Authors. Authors and Contributors [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.9.1/OWNERS) and [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.9.1/OWNERS_ALIASES)
+    - Version: v4.12.1
+    - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.12.1/LICENSE)
+    - Source: <https://github.com/kubernetes/ingress-nginx/tree/helm-chart-4.12.1/charts/ingress-nginx>
+    - Copyright: Copyright The ingress-nginx Authors. Authors and Contributors [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.12.1/OWNERS) and [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.12.1/OWNERS_ALIASES)
   - Container image(s)
-    - registry.k8s.io/ingress-nginx/controller:v1.9.6
-      - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/controller-v1.9.6/LICENSE)
-    - docker.io/library/nginx:1.25.2-alpine
-      - License: [BSD 2-Clause "Simplified" License](https://github.com/nginxinc/docker-nginx/blob/1.25.2/LICENSE)
+    - registry.k8s.io/ingress-nginx/controller:v1.12.1
+      - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/controller-v1.12.1/LICENSE)
+    - docker.io/library/nginx:1.25.5-alpine
+      - License: [BSD 2-Clause "Simplified" License](https://github.com/nginxinc/docker-nginx/blob/1.25.5/LICENSE)
   
 - Grafana Operator
   - Helm chart: *None*

--- a/apps/01-ingress-nginx/kustomization.yaml
+++ b/apps/01-ingress-nginx/kustomization.yaml
@@ -19,6 +19,6 @@ helmCharts:
 - name: ingress-nginx
   repo: https://kubernetes.github.io/ingress-nginx
   releaseName: "{{ app_name }}"
-  version: v4.9.1
+  version: v4.12.1
   namespace: ingress-nginx
   valuesFile: values.yaml


### PR DESCRIPTION
Update for three reasons:
- 1.12.1 includes fix for [CVE-2025-1974](https://github.com/kubernetes/kubernetes/issues/131009) (rated 9.8)
- OVH MKS uses Kubernetes 1.32 but the current version we use (1.9.6) is only said compatible up to 1.29
- Kubernetes do not offer security support for version 1.9.x, only 1.11 and 1.12