### PR TITLE
RSPY-664 - use smaller nodes for staging

### DIFF
--- a/roles/terraform/cluster/tasks/cluster.tf
+++ b/roles/terraform/cluster/tasks/cluster.tf
@@ -90,7 +90,7 @@ resource "ovh_cloud_project_kube_nodepool" "nodepool_processing" {
 resource "ovh_cloud_project_kube_nodepool" "nodepool_access_csc" {
   kube_id       = ovh_cloud_project_kube.cluster.id
   name          = "access-csc-${var.cluster_name}"
-  flavor_name   = "b3-16"
+  flavor_name   = "b3-8"
   desired_nodes = var.nodepool_access_csc_desired_nodes
   min_nodes     = 0
   max_nodes     = 5


### PR DESCRIPTION
Staging does not need a lot of cpu or ram, but aims at dispatch several dask workers on several nodes to maximize the network throughput.

Our tests show that when scaling the workers on b3-16 instances, several dask workers are hosted on a same node, thus sharing the same network interface. Testing with Matera and Svalbard, we got network speed between 300 Mb/s to 600 Mb/s on a single worker, we never managed to get higher speed, close to the 1 Gb/s limit advertised for b3-16 instance.

By using a smaller node model, we maximize the chance to have the dask workers split on several nodes, thus increasing the overall speed, at a lower cost:

https://www.ovhcloud.com/fr/public-cloud/prices/