### PR TITLE
feat: add operational and dask-gateway rolebinding

### DIFF
--- a/apps/03-kubectl-oidc/rolebindings.yaml
+++ b/apps/03-kubectl-oidc/rolebindings.yaml
@@ -140,6 +140,34 @@ roleRef:
   name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keycloak-cluster-operator
+  namespace: operational
+subjects:
+  - kind: Group
+    name: operator
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keycloak-cluster-operator
+  namespace: dask-gateway
+subjects:
+  - kind: Group
+    name: operator
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
 # cluster-networking keycloak client role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Add operational and dask-gateway rolebinding for kubectl oidc.