### PR TITLE
Docker image generation fixes and optims

### DIFF
--- a/.github/actions/publish-docker/action.yml
+++ b/.github/actions/publish-docker/action.yml
@@ -100,12 +100,12 @@ runs:
         output: trivy-results-docker.sarif
         exit-code: 0
         #severity: HIGH,CRITICAL
+        skip-dirs: /opt/conda/pkgs/cache
+        skip-files: /opt/conda/lib/python3.11/site-packages/bokeh/server/static/js/compiler.js,/opt/conda/lib/python3.11/site-packages/prefect/server/ui/assets/index-CCNfsmcm.js.map
         timeout: '30m'
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
-      # TO BE REMOVED once the repository is public
-      continue-on-error: true
       with:
         sarif_file: trivy-results-docker.sarif
         category: ${{ env.docker_image }}

--- a/.github/common/resources/layer-cleanup.sh
+++ b/.github/common/resources/layer-cleanup.sh
@@ -27,5 +27,6 @@ rm -rf /usr/local/share/.cache/*
 # including /usr/local/share/.cache/yarn
 
 rm -rf /tmp/* /var/tmp/*
+rm -rf /opt/conda/pkgs/cache
 
 exit 0

--- a/.github/jupyter/Dockerfile
+++ b/.github/jupyter/Dockerfile
@@ -23,8 +23,8 @@ USER root
 
 RUN adduser rspy
 
-ENV SHELL /bin/bash
-ENV HOME /home/rspy
+ENV SHELL=/bin/bash
+ENV HOME=/home/rspy
 
 COPY ./*.whl /opt/
 COPY ./resources/layer-cleanup.sh /usr/local/bin/
@@ -46,7 +46,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && \
     layer-cleanup.sh
 
 # Install python dependencies
-RUN conda install --yes conda-forge::python=${PYTHON_TAG} && \
+RUN conda update -n base -c conda-forge conda && \
+    conda install --yes conda-forge::python=${PYTHON_TAG} && \
+    pip install --upgrade pip && \
     pip install \
     dask[complete]==${DASK_TAG} \
     distributed==${DASK_TAG} \


### PR DESCRIPTION
Jupyter "publish docker" step goes from 8 minutes to 4 minutes, because the Trivy scan was parsing huge conda cache files.