### PR TITLE
feat: skip docker build when not mandatory

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -18,9 +18,13 @@ name: Publish Docker image
 on:
   pull_request: # pull requests
     types: [opened, synchronize, reopened]
+    paths:
+      - '.github/**'
   push:
     branches:
       - develop # pushes on the 'develop' branch
+    paths:
+      - '.github/**'
     tags:
       - '**' # new git tags (including hierarchical tags like v1.0/beta)
   workflow_dispatch: # manual trigger


### PR DESCRIPTION
Skip docker build when no changes are made in .github folder, where the Dockerfile and the resources are stored.