### PR TITLE
fix: add gitlab token for private repo

### DIFF
--- a/.github/common/resources/requirements-dask-eopf.txt
+++ b/.github/common/resources/requirements-dask-eopf.txt
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
---extra-index-url https://gitlab.eopf.copernicus.eu/api/v4/projects/94/packages/pypi/simple # orekit jcc
---extra-index-url https://gitlab.eopf.copernicus.eu/api/v4/projects/67/packages/pypi/simple # sxgeo
---extra-index-url https://gitlab.eopf.copernicus.eu/api/v4/projects/78/packages/pypi/simple # pyrugged
---extra-index-url https://gitlab.eopf.copernicus.eu/api/v4/projects/52/packages/pypi/simple # asgard
---extra-index-url https://gitlab.eopf.copernicus.eu/api/v4/projects/14/packages/pypi/simple # eopf cpm
+--extra-index-url https://__token__:${GITLAB_EOPF_TOKEN}@gitlab.eopf.copernicus.eu/api/v4/projects/94/packages/pypi/simple # orekit jcc
+--extra-index-url https://__token__:${GITLAB_EOPF_TOKEN}@gitlab.eopf.copernicus.eu/api/v4/projects/67/packages/pypi/simple # sxgeo
+--extra-index-url https://__token__:${GITLAB_EOPF_TOKEN}@gitlab.eopf.copernicus.eu/api/v4/projects/78/packages/pypi/simple # pyrugged
+--extra-index-url https://__token__:${GITLAB_EOPF_TOKEN}@gitlab.eopf.copernicus.eu/api/v4/projects/52/packages/pypi/simple # asgard
+--extra-index-url https://__token__:${GITLAB_EOPF_TOKEN}@gitlab.eopf.copernicus.eu/api/v4/projects/14/packages/pypi/simple # eopf cpm
 #--extra-index-url https://__token__:${GITLAB_EOPF_TOKEN}@gitlab.eopf.copernicus.eu/api/v4/projects/102/packages/pypi/simple # l0
 #l0==1.0.0
 git+https://__token__:${GITLAB_EOPF_TOKEN}@gitlab.eopf.copernicus.eu/jgaucher/l0@develop


### PR DESCRIPTION
All the GitLab repo switched from public to private, so we have to add the token to authenticate.