### PR TITLE
RSPY-667 - Define rs_server.full_domain variable

### DIFF
--- a/inventory/sample/host_vars/setup/apps.yml
+++ b/inventory/sample/host_vars/setup/apps.yml
@@ -119,6 +119,7 @@ rs_server:
     password: test
     username: test
     secret: pygeoapi-database-password
+  full_domain: "{{ platform_domain_name }}"
 
 rs_performance_indicator:
   database:
@@ -423,7 +424,7 @@ rs_osam:
       # Create a new API key or re-use the one you used to set up the ovh managed k8s
       # AK, AS and CK on https://www.ovh.com/auth/api/createToken
       # with GET, POST, PUT, DELETE on *
-      ovh_endpoint: "ovh-eu"    
+      ovh_endpoint: "ovh-eu"
       ovh_application_key: ""
       ovh_application_secret: ""
       ovh_consumer_key: ""


### PR DESCRIPTION
Define `rs_server.full_domain` to match ops deployment and ease automatic installation from rs-server-deployment git repository on our platform.