### PR TITLE
Update to oauth2-proxy helm chart 8.2.1 / oauth2-proxy 7.12.0

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -127,13 +127,13 @@ Below are all the FOSS (Free and open-source software) used and their respective
 
 - oauth2-proxy
   - Helm chart:
-    - Version: 7.1.0
-    - Licence: [Apache License 2.0](https://github.com/oauth2-proxy/manifests/blob/oauth2-proxy-7.1.0/LICENSE)
-    - Source: <https://github.com/oauth2-proxy/manifests/tree/oauth2-proxy-7.1.0>
+    - Version: 8.2.1
+    - Licence: [Apache License 2.0](https://github.com/oauth2-proxy/manifests/blob/oauth2-proxy-8.2.1/LICENSE)
+    - Source: <https://github.com/oauth2-proxy/manifests/tree/oauth2-proxy-8.2.1>
     - Copyright: Copyright The oauth2-proxy Development Team. [Authors and Contributors](https://github.com/oauth2-proxy/manifests/graphs/contributors)
   - Container image(s)
-    - quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
-      - License: [MIT License](https://github.com/oauth2-proxy/oauth2-proxy/blob/v7.6.0/LICENSE)
+    - quay.io/oauth2-proxy/oauth2-proxy:v7.12.0
+      - License: [MIT License](https://github.com/oauth2-proxy/oauth2-proxy/blob/v7.12.0/LICENSE)
 
 - Prefect
   - Helm chart:

--- a/apps/oauth2-proxy/kustomization.yaml
+++ b/apps/oauth2-proxy/kustomization.yaml
@@ -21,7 +21,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://oauth2-proxy.github.io/manifests
   valuesFile: values.yaml
-  version: 7.17.0
+  version: 8.2.1
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:

--- a/apps/oauth2-proxy/values.yaml
+++ b/apps/oauth2-proxy/values.yaml
@@ -51,9 +51,10 @@ ingress:
 
 sessionStorage:
   type: redis
+  redis:
+    clientType: "standalone"
 redis:
   enabled: true
-  architecture: standalone
   master:
     affinity:
       nodeAffinity:

--- a/apps/oauth2-proxy/values.yaml
+++ b/apps/oauth2-proxy/values.yaml
@@ -55,6 +55,9 @@ sessionStorage:
     clientType: "standalone"
 redis:
   enabled: true
+  replicas: 1
+  persistentVolume:
+    enabled: false
   master:
     affinity:
       nodeAffinity:

--- a/apps/oauth2-proxy/values.yaml
+++ b/apps/oauth2-proxy/values.yaml
@@ -56,6 +56,9 @@ sessionStorage:
 redis:
   enabled: true
   replicas: 1
+  redis:
+    config:
+      min-replicas-to-write: 0
   persistentVolume:
     enabled: false
   master:

--- a/roles/app-installer/tasks/install_app.yaml
+++ b/roles/app-installer/tasks/install_app.yaml
@@ -223,7 +223,7 @@
           - "app.kubernetes.io/instance={{ app_name }}"
         wait: true
         wait_sleep: 1
-        wait_timeout: 120
+        wait_timeout: 360
       when: pods.resources | length > 0
       delegate_to: bastion
 

--- a/roles/app-installer/tasks/install_app.yaml
+++ b/roles/app-installer/tasks/install_app.yaml
@@ -96,8 +96,8 @@
     - name: "{{ package_name }} - {{ app_name }} | Deploy resources"
       shell: |
         kustomize build --enable-helm {{ resources_dir.path }} \
-        | yq eval 'select(.metadata.annotations."helm.sh/hook" != "test")' - \
-                {% if private_registry | bool %} \
+        | yq eval 'select(.metadata.annotations."helm.sh/hook" != "test" and .metadata.annotations."helm.sh/hook" != "test-success")' - \
+        {% if private_registry | bool %} \
         | sed -E '/image:/ {
           /image: (docker.io\/)?([a-z0-9\-]+\/[a-z0-9\-]+)(:[^@ ]+)?(@sha256:[a-f0-9]{64})?/ {
             s|image: (docker.io\/)?([a-z0-9\-]+\/[a-z0-9\-]+)(:[^@ ]+)?(@sha256:[a-f0-9]{64})?|image: {{ registry.harbor_url | regex_replace('^https?://', '') }}/proxycache/\2\3\4|


### PR DESCRIPTION
**Update to:**
- https://github.com/oauth2-proxy/manifests/releases/tag/oauth2-proxy-8.0.0
- https://github.com/oauth2-proxy/manifests/releases/tag/oauth2-proxy-8.0.1
- https://github.com/oauth2-proxy/manifests/releases/tag/oauth2-proxy-8.1.0
- https://github.com/oauth2-proxy/manifests/releases/tag/oauth2-proxy-8.1.1
- https://github.com/oauth2-proxy/manifests/releases/tag/oauth2-proxy-8.2.0
- https://github.com/oauth2-proxy/manifests/releases/tag/oauth2-proxy-8.2.1

**Breaking changes:**

> Version 8.0.0 of the helm chart removes the dependency on the Bitnami Redis subchart and replaces it with the dandydeveloper/redis-ha chart. Therefore this version introduces a breaking change to the redis subchart deployment configuration.
> 
> Read more about it [here.](https://github.com/oauth2-proxy/manifests/tree/main/helm/oauth2-proxy#to-800---bitnami-)