### PR TITLE
RSPY-766 - Add plotting python libraries in jupyter docker image

### DIFF
--- a/.github/jupyter/Dockerfile
+++ b/.github/jupyter/Dockerfile
@@ -57,7 +57,12 @@ RUN conda update -n base -c conda-forge conda && \
     ipywidgets \
     dask-labextension \
     s3fs \
-    boto3 && \
+    boto3 \
+    xarray \
+    cartopy \
+    geopandas \
+    matplotlib \
+    stac-api-validator && \
     pip install /opt/*.whl && \
     conda clean --all --yes && \
     layer-cleanup.sh


### PR DESCRIPTION
Add plotting libraries required to plot ZARR data as showcased in EOPF tutorial:

https://eopf-sample-service.github.io/eopf-sample-notebooks/sentinel-2-l1c-msi-zarr-product-exploration/#introduction