### PR TITLE
test real deployment in ci/cd

### DIFF
--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -42,32 +42,43 @@ jobs:
 
           # Init conda
           ~/miniforge3/bin/conda init bash
+          conda update -n base -c defaults conda
 
           # Create conda env with python
           # conda update -n base -c defaults conda
           conda create -y -n rspy python=3.11
 
           # Install Ansible, Terraform, Openstackclient
-          conda run -n rspy conda install -y -c conda-forge ansible terraform python-openstackclient passlib boto3 kubernetes-helm kubernetes-client
+          conda run -n rspy conda install -y -c conda-forge ansible terraform python-openstackclient passlib boto3 kubernetes-helm kubernetes-client python-kubernetes
 
-          conda run -n rspy ansible-galaxy collection install openstack.cloud amazon.aws
+          conda run -n rspy ansible-galaxy collection install openstack.cloud amazon.aws kubernetes.core
+          ln -s /usr/share/miniconda/envs/rspy/bin/kubectl /usr/local/bin/kubectl
         shell: bash
       - name: Start minikube
         uses: medyagh/setup-minikube@latest
+        with:
+          start-args: '--profile cluster.local'
+          memory: 8000m
+      - name: "Configure cluster"
+        run: |
+          kubectl label node cluster.local node-role.kubernetes.io/infra=
+        shell: bash
       - name: Generate inventory
         run: |
           cp -rfp inventory/sample inventory/mycluster
-          cp -rfp inventory/mycluster/.env.template inventory/mycluster/.env
-          cp -rfp inventory/mycluster/openrc.sh.template inventory/mycluster/openrc.sh
+          mv inventory/mycluster/.env.template inventory/mycluster/.env
+          mv inventory/mycluster/openrc.sh.template inventory/mycluster/openrc.sh
           sed -i 's!<changeme_with_full_path>/miniforge3/envs/rspy!/usr/share/miniconda/envs/rspy!g' inventory/mycluster/hosts.yaml
-          conda run -n rspy ansible-playbook generate_inventory.yaml -i inventory/mycluster/hosts.yaml
+          conda run -n rspy --no-capture-output env PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=1 ansible-playbook generate_inventory.yaml -i inventory/mycluster/hosts.yaml
         shell: bash
-#      - name: "Create and configure machines (check)"
-#        run: |
-#          conda run -n rspy ansible-playbook --check cluster.yaml -i inventory/mycluster/hosts.yaml
-#        shell: bash
       - name: Deploy the apps (check)
         run: |
-          ln -s /usr/share/miniconda/envs/rspy/bin/kubectl /usr/local/bin/kubectl
-          conda run -n rspy ansible-playbook --check apps.yaml -i inventory/mycluster/hosts.yaml
+          conda run -n rspy --no-capture-output env PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=1 ansible-playbook --check apps.yaml -i inventory/mycluster/hosts.yaml
+        shell: bash
+      - name: Deploy the apps (for real)
+        run: |
+          sed -i 's!debug: false!debug: true!g' roles/app-installer/tasks/install_app.yaml
+          sed -i 's!csi-cinder-high-speed-retain!standard!g' apps/01-cloudnative-pg/cluster.yaml
+          sed -i -e 's!https://iam.{{ platform_domain_name }}!http://keycloak-service.iam.svc.cluster.local:8080!g' -e 's!insecure_oidc_skip_issuer_verification="false"!insecure_oidc_skip_issuer_verification="true"!g' apps/oauth2-proxy/values.yaml
+          conda run -n rspy --no-capture-output env PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=1 ansible-playbook -v apps.yaml -i inventory/mycluster/hosts.yaml
         shell: bash

--- a/apps/04-keycloak-db/database.yaml
+++ b/apps/04-keycloak-db/database.yaml
@@ -19,6 +19,9 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 360
   template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: '{{ app_name }}'
     spec:
       containers:
       - name: create-keycloak-db

--- a/apps/oauth2-proxy/kustomization.yaml
+++ b/apps/oauth2-proxy/kustomization.yaml
@@ -12,15 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 
 namespace: iam
 
 helmCharts:
 - name: oauth2-proxy
   namespace: iam
+  releaseName: '{{ app_name }}'
   repo: https://oauth2-proxy.github.io/manifests
-  releaseName: "{{ app_name }}"
-  version: 7.17.0
   valuesFile: values.yaml
+  version: 7.17.0
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/oauth2-proxy/values.yaml
+++ b/apps/oauth2-proxy/values.yaml
@@ -28,6 +28,7 @@ config:
     whitelist_domains=".{{ platform_domain_name }}"
     email_domains=[ "*" ]
     cookie_domains=".{{ platform_domain_name }}"
+    insecure_oidc_skip_issuer_verification="false"
     insecure_oidc_allow_unverified_email="true"
     reverse_proxy="true"
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -61,8 +61,10 @@ conda install conda-forge::passlib
 conda install conda-forge::boto3
 conda install conda-forge::kubernetes-helm
 conda install conda-forge::kubernetes-client
+conda install conda-forge::python-kubernetes
 
 ansible-galaxy collection install \
+    kubernetes.core \
     openstack.cloud \
     amazon.aws
 ```

--- a/inventory/sample/hosts.yaml
+++ b/inventory/sample/hosts.yaml
@@ -25,3 +25,4 @@ all:
     bastion:
       ansible_connection: local
       ansible_host: 127.0.0.1
+      ansible_python_interpreter: <changeme_with_full_path>/miniforge3/envs/rspy/bin/python3.11

--- a/roles/app-installer/tasks/install_app.yaml
+++ b/roles/app-installer/tasks/install_app.yaml
@@ -120,6 +120,132 @@
         dest: "{{ app_dir }}/resources.txt"
       delegate_to: bastion
 
+    - name: "{{ package_name }} - {{ app_name }} | Detect jobs for this app"
+      kubernetes.core.k8s_info:
+        kind: Job
+        label_selectors:
+          - "app.kubernetes.io/instance = {{ app_name }}"
+      register: jobs
+      delegate_to: bastion
+
+    - name: "{{ package_name }} - {{ app_name }} | Wait until jobs are complete (if any)"
+      kubernetes.core.k8s_info:
+        kind: Job
+        label_selectors:
+          - "app.kubernetes.io/instance = {{ app_name }}"
+        wait: true
+        wait_sleep: 1
+        wait_timeout: 120
+        wait_condition:
+          type: Complete
+      when: jobs.resources | length > 0
+      delegate_to: bastion
+
+    - name: "{{ package_name }} - {{ app_name }} | Detect pods for this app"
+      kubernetes.core.k8s_info:
+        kind: Pod
+        label_selectors:
+          - "!job-name"
+          - "app.kubernetes.io/instance={{ app_name }}"
+      register: pods
+      delegate_to: bastion
+
+    - name: "{{ package_name }} - {{ app_name }} | Wait until pods are ready (if any)"
+      kubernetes.core.k8s_info:
+        kind: Pod
+        label_selectors:
+          - "!job-name"
+          - "app.kubernetes.io/instance={{ app_name }}"
+        wait: true
+        wait_sleep: 1
+        wait_timeout: 120
+      when: pods.resources | length > 0
+      delegate_to: bastion
+
+    - name: "{{ package_name }} - {{ app_name }} | Detect deployments for this app"
+      kubernetes.core.k8s_info:
+        kind: Deployment
+        label_selectors:
+          - "app.kubernetes.io/instance = {{ app_name }}"
+      register: deployments
+      delegate_to: bastion
+
+    - name: "{{ package_name }} - {{ app_name }} | Wait until deployments are ready (if any)"
+      kubernetes.core.k8s_info:
+        kind: Deployment
+        label_selectors:
+          - "app.kubernetes.io/instance = {{ app_name }}"
+        wait: true
+        wait_sleep: 1
+        wait_timeout: 120
+      when: deployments.resources | length > 0
+      delegate_to: bastion
+
+  rescue:
+    - name: "{{ package_name }} - {{ app_name }} | Show jobs status"
+      debug:
+        var: jobs.resources
+      when: jobs.resources | length > 0
+
+    - name: "{{ package_name }} - {{ app_name }} | Get logs of each job"
+      kubernetes.core.k8s_log:
+        name: "{{ item.metadata.name }}"
+        namespace: "{{ item.metadata.namespace }}"
+      loop: "{{ jobs.resources }}"
+      when: jobs.resources | length > 0
+      ignore_errors: true
+      register: job_logs
+      delegate_to: bastion
+
+    - name: "{{ package_name }} - {{ app_name }} | Show jobs logs"
+      debug:
+        var: job_logs
+      when: jobs.resources | length > 0
+
+    - name: "{{ package_name }} - {{ app_name }} | Show pods status"
+      debug:
+        var: pods.resources
+      when: pods.resources | length > 0
+
+    - name: "{{ package_name }} - {{ app_name }} | Get logs of each pod"
+      kubernetes.core.k8s_log:
+        name: "{{ item.metadata.name }}"
+        namespace: "{{ item.metadata.namespace }}"
+      loop: "{{ pods.resources }}"
+      when: pods.resources | length > 0
+      ignore_errors: true
+      register: pod_logs
+      delegate_to: bastion
+
+    - name: "{{ package_name }} - {{ app_name }} | Show pods logs"
+      debug:
+        var: pod_logs
+      when: pods.resources | length > 0
+
+    - name: "{{ package_name }} - {{ app_name }} | Show deployments status"
+      debug:
+        var: deployments.resources
+      when: deployments.resources | length > 0
+
+    - name: "{{ package_name }} - {{ app_name }} | Get logs of each deployment"
+      kubernetes.core.k8s_log:
+        name: "{{ item.metadata.name }}"
+        namespace: "{{ item.metadata.namespace }}"
+      loop: "{{ deployments.resources }}"
+      when: deployments.resources | length > 0
+      ignore_errors: true
+      register: deployment_logs
+      delegate_to: bastion
+
+    - name: "{{ package_name }} - {{ app_name }} | Show deployments logs"
+      debug:
+        var: deployment_logs
+      when: deployments.resources | length > 0
+
+    - name: "{{ package_name }} - {{ app_name }} | Fail the playbook"
+      fail:
+        msg: "Deployment {{ app_name }} failed! See debug info above."
+
   always:
     - name: "{{ package_name }} - {{ app_name }} | Remove resources tmp dir"
       file:


### PR DESCRIPTION
Check a real deployment in Github Actions:
- name the minikube cluster 'cluster.local' as per real deployments
- install [kubernetes.core](https://github.com/ansible-collections/kubernetes.core) ansible collection
- label the minikube node with `node-role.kubernetes.io/infra` so that pods expected this affinity are created
- display ansible logs in color and in real time to ease debugging
- enable debug deployment to ease debugging
- in CI, change csi-cinder-high-speed-retain storage class to standard as Minikube does not provide cinder out of the box
- In CI, change oauth2-proxy configuration to contact internal keycloak service for OIDC discovery, and skip issuer verification as keycloak always returns 'https://<hostname>' instead of contacted URL
- add missing label to the pod created by the create-keycloak-db job
- fix deprecation warnings in oauth2-proxy kustomization
- add missing ansible_python_interpreter for ansible bastion configuration
- in app installer script, wait after each resources deployment that Kubernetes jobs, pods and deployments are complete/ready if any. It fixes RSPY-176 issue. Otherwise, the resource deployments are too fast and fail because dependencies deployed earlier are not ready yet. 
- in app installer script, add a rescue directive that prints many debug information to ease debugging
- update documentation 

Followup:
- https://github.com/RS-PYTHON/rs-infra-monitoring/pull/21