### PR TITLE
RSPY-688 - Update to Keycloak 26.4.0

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -66,10 +66,10 @@ Below are all the FOSS (Free and open-source software) used and their respective
 - Keycloak
   - Helm chart: *None*
   - Container image(s)
-    - quay.io/keycloak/keycloak:23.0.6
-      - License: [Apache License 2.0](https://github.com/keycloak/keycloak/blob/23.0.6/LICENSE.txt)
-    - quay.io/keycloak/keycloak-operator:23.0.6
-      - License: [Apache License 2.0](https://github.com/keycloak/keycloak/blob/23.0.6/LICENSE.txt)
+    - quay.io/keycloak/keycloak:24.0.5
+      - License: [Apache License 2.0](https://github.com/keycloak/keycloak/blob/24.0.5/LICENSE.txt)
+    - quay.io/keycloak/keycloak-operator:24.0.5
+      - License: [Apache License 2.0](https://github.com/keycloak/keycloak/blob/24.0.5/LICENSE.txt)
 
 - CoreDNS
   - Helm chart: *None*

--- a/apps/00-crds-keycloak/kustomization.yaml
+++ b/apps/00-crds-keycloak/kustomization.yaml
@@ -14,8 +14,8 @@
 
 
 resources:
-- https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/refs/tags/23.0.6/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
-- https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/refs/tags/23.0.6/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
+- https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/refs/tags/24.0.5/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
+- https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/refs/tags/24.0.5/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:

--- a/apps/03-keycloak-operator/deployment.yaml
+++ b/apps/03-keycloak-operator/deployment.yaml
@@ -16,19 +16,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/version: 23.0.6
+    app.kubernetes.io/version: 24.0.5
     app.kubernetes.io/name: keycloak-operator
   name: keycloak-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/version: 23.0.6
+      app.kubernetes.io/version: 24.0.5
       app.kubernetes.io/name: keycloak-operator
   template:
     metadata:
       labels:
-        app.kubernetes.io/version: 23.0.6
+        app.kubernetes.io/version: 24.0.5
         app.kubernetes.io/name: keycloak-operator
     spec:
       containers:

--- a/apps/03-keycloak-operator/rbac.yaml
+++ b/apps/03-keycloak-operator/rbac.yaml
@@ -19,7 +19,7 @@ metadata:
   annotations:
     app.quarkus.io/build-timestamp: 2024-02-02 - 14:20:56 +0000
   labels:
-    app.kubernetes.io/version: 23.0.6
+    app.kubernetes.io/version: 24.0.5
     app.kubernetes.io/name: keycloak-operator
   name: keycloak-operator
 ---

--- a/apps/03-keycloak-operator/service.yaml
+++ b/apps/03-keycloak-operator/service.yaml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 23.0.6
+    app.kubernetes.io/version: 24.0.5
   name: keycloak-operator
 spec:
   ports:
@@ -27,5 +27,5 @@ spec:
       targetPort: 8080
   selector:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 23.0.6
+    app.kubernetes.io/version: 24.0.5
   type: ClusterIP

--- a/apps/05-keycloak/keycloak.yaml
+++ b/apps/05-keycloak/keycloak.yaml
@@ -38,8 +38,6 @@ spec:
     enabled: false
   instances: {{ keycloak.replicaCount }}
   additionalOptions:
-    - name: proxy
-      value: "{{ keycloak.proxy.mode }}"
     - name: log-level
       value: "{{ keycloak.logLevel }}"
     - name: metrics-enabled

--- a/inventory/sample/host_vars/setup/apps.yml
+++ b/inventory/sample/host_vars/setup/apps.yml
@@ -77,9 +77,9 @@ postgresql:
   instances: 3
 
 keycloak:
-  image: quay.io/keycloak/keycloak:23.0.6
+  image: quay.io/keycloak/keycloak:24.0.5
   operator:
-    image: quay.io/keycloak/keycloak-operator:23.0.6
+    image: quay.io/keycloak/keycloak-operator:24.0.5
   database:
     host: postgresql-cluster-rw.database.svc.cluster.local
     name: keycloak
@@ -90,8 +90,6 @@ keycloak:
     interval: 30s
     scrapeTimeout: 10s
   replicaCount: 1
-  proxy:
-    mode: passthrough
   logLevel: info
   realm:
     name: rspy


### PR DESCRIPTION
Update to:
- https://github.com/keycloak/keycloak/releases/tag/24.0.0
- https://github.com/keycloak/keycloak/releases/tag/25.0.0
- https://github.com/keycloak/keycloak/releases/tag/26.0.0
- https://github.com/keycloak/keycloak/releases/tag/26.1.0
- https://github.com/keycloak/keycloak/releases/tag/26.2.0
- https://github.com/keycloak/keycloak/releases/tag/26.3.0
- https://github.com/keycloak/keycloak/releases/tag/26.3.5
- https://github.com/keycloak/keycloak/releases/tag/26.4.0

Changes:

**24.0.0 - Changes to the Account Console theme customization**
https://www.keycloak.org/docs/26.4.0/upgrading/#changes-to-the-account-console-theme-customization

> To move your custom theme start by changing the parent to the new theme:

```
# Before
parent=keycloak.v2

# After
parent=keycloak.v3
```

**24.0.0 - Deprecated --proxy option**
https://www.keycloak.org/docs/latest/upgrading/index.html#deprecated-proxy-option

>The --proxy option has been deprecated and will be removed in a future release. The following table explains how the deprecated option maps to supported options.

> (...)

> 

> You can also set the proxy headers when using the Operator:

```yaml
apiVersion: k8s.keycloak.org/v2alpha1
kind: Keycloak
metadata:
  name: example-kc
spec:
  ...
  proxy:
    headers: forwarded|xforwarded
```

>  If the proxy.headers field is not specified, the Operator falls back to the previous behavior by implicitly setting proxy=passthrough by default. This results in deprecation warnings in the server log. This fallback will be removed in a future release. 

**26.4.0 - Operator creates a ServiceMonitor automatically**

> The Operator now provisions a ServiceMonitor for the management endpoint if metrics are enabled and the monitoring.coreos.com/v1:ServiceMonitor Custom Resource Definition is present on the Kubernetes cluster. The specification of the ServiceMonitor takes into account the various management endpoint configurations, to ensure that metrics can be scraped without any additional configuration. If you do not want a ServiceMonitor to be created, you can disable this by setting spec.serviceMonitor.enabled: false. For more details, see the [Operator Guide](https://www.keycloak.org/guides#operator).