### PR TITLE
Improve deployment tests

### DIFF
--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Deploy the apps (for real)
         run: |
           sed -i 's!debug: false!debug: true!g' roles/app-installer/tasks/install_app.yaml
-          sed -i 's!csi-cinder-high-speed-retain!standard!g' apps/01-cloudnative-pg/cluster.yaml
+          sed -i 's!cinder.csi.openstack.org!k8s.io/minikube-hostpath!g' apps/00-storage-class/sc-retain.yaml
           sed -i -e 's!https://iam.{{ platform_domain_name }}!http://keycloak-service.iam.svc.cluster.local:8080!g' -e 's!insecure_oidc_skip_issuer_verification="false"!insecure_oidc_skip_issuer_verification="true"!g' apps/oauth2-proxy/values.yaml
           conda run -n rspy --no-capture-output env PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=1 ansible-playbook -v apps.yaml -i inventory/mycluster/hosts.yaml
         shell: bash

--- a/roles/app-installer/tasks/install_app.yaml
+++ b/roles/app-installer/tasks/install_app.yaml
@@ -217,6 +217,7 @@
       kubernetes.core.k8s_log:
         name: "{{ item.metadata.name }}"
         namespace: "{{ item.metadata.namespace }}"
+        all_containers: true
       loop: "{{ jobs.resources }}"
       when: jobs.resources | length > 0
       ignore_errors: true
@@ -237,6 +238,7 @@
       kubernetes.core.k8s_log:
         name: "{{ item.metadata.name }}"
         namespace: "{{ item.metadata.namespace }}"
+        all_containers: true
       loop: "{{ pods.resources }}"
       when: pods.resources | length > 0
       ignore_errors: true
@@ -257,6 +259,7 @@
       kubernetes.core.k8s_log:
         name: "{{ item.metadata.name }}"
         namespace: "{{ item.metadata.namespace }}"
+        all_containers: true
       loop: "{{ deployments.resources }}"
       when: deployments.resources | length > 0
       ignore_errors: true


### PR DESCRIPTION
Two improvements for deployment tests in CI/CD:
- Retrieve logs of all containers, otherwise the workflow fails to retrieve logs of pods with several containers
- Change the storage class provider so that it can be used by applications in minikube, instead of avoiding the storage class completely. This simplifies the CI/CD in rs-infra-monitoring where the storage class is used several times