### PR TITLE
Update to ingress-nginx 1.12.5

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -20,13 +20,13 @@ Below are all the FOSS (Free and open-source software) used and their respective
 
 - NGINX Ingress Controller :
   - Helm chart
-    - Version: v4.12.1
-    - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.12.1/LICENSE)
-    - Source: <https://github.com/kubernetes/ingress-nginx/tree/helm-chart-4.12.1/charts/ingress-nginx>
-    - Copyright: Copyright The ingress-nginx Authors. Authors and Contributors [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.12.1/OWNERS) and [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.12.1/OWNERS_ALIASES)
+    - Version: v4.12.5
+    - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.12.5/LICENSE)
+    - Source: <https://github.com/kubernetes/ingress-nginx/tree/helm-chart-4.12.5/charts/ingress-nginx>
+    - Copyright: Copyright The ingress-nginx Authors. Authors and Contributors [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.12.5/OWNERS) and [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.12.5/OWNERS_ALIASES)
   - Container image(s)
-    - registry.k8s.io/ingress-nginx/controller:v1.12.1
-      - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/controller-v1.12.1/LICENSE)
+    - registry.k8s.io/ingress-nginx/controller:v1.12.5
+      - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/controller-v1.12.5/LICENSE)
     - docker.io/library/nginx:1.25.5-alpine
       - License: [BSD 2-Clause "Simplified" License](https://github.com/nginxinc/docker-nginx/blob/1.25.5/LICENSE)
 

--- a/apps/01-ingress-nginx/kustomization.yaml
+++ b/apps/01-ingress-nginx/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://kubernetes.github.io/ingress-nginx
   valuesFile: values.yaml
-  version: v4.12.1
+  version: v4.12.5
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:

--- a/apps/01-ingress-nginx/kustomization.yaml
+++ b/apps/01-ingress-nginx/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://kubernetes.github.io/ingress-nginx
   valuesFile: values.yaml
-  version: v4.12.5
+  version: v4.12.3
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:


### PR DESCRIPTION
Update to:
- https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.12.5
- https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.12.4
- https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.12.3
- https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.12.2

Which brings updates of:
- https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.12.5
- https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.12.4
- https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.12.3
- https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.12.2