### PR TITLE
Improve cloudnative-pg deployment

### DIFF
--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -58,6 +58,7 @@ jobs:
         uses: medyagh/setup-minikube@latest
         with:
           start-args: '--profile cluster.local'
+          cpus: 4
           memory: 8000m
       - name: "Configure cluster"
         run: |
@@ -80,6 +81,7 @@ jobs:
         run: |
           sed -i 's!debug: false!debug: true!g' roles/app-installer/tasks/install_app.yaml
           sed -i 's!cinder.csi.openstack.org!k8s.io/minikube-hostpath!g' apps/00-storage-class/sc-retain.yaml
+          sed -i 's!instances: 3!instances: 2!g' apps/01-cloudnative-pg/cluster.yaml
           sed -i -e 's!https://iam.{{ platform_domain_name }}!http://keycloak-service.iam.svc.cluster.local:8080!g' -e 's!insecure_oidc_skip_issuer_verification="false"!insecure_oidc_skip_issuer_verification="true"!g' apps/oauth2-proxy/values.yaml
-          conda run -n rspy --no-capture-output env PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=1 ansible-playbook -v apps.yaml -i inventory/mycluster/hosts.yaml
+          conda run -n rspy --no-capture-output env PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=1 ansible-playbook apps.yaml -i inventory/mycluster/hosts.yaml
         shell: bash

--- a/apps/00-crds-grafana-operator/kustomization.yaml
+++ b/apps/00-crds-grafana-operator/kustomization.yaml
@@ -16,7 +16,7 @@ namePrefix: grafana-operator-
 
 
 resources:
-- https://raw.githubusercontent.com/grafana/grafana-operator/refs/tags/v5.9.0/deploy/kustomize/base/crds.yaml
+- https://github.com/grafana/grafana-operator/releases/download/v5.18.0/crds.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:

--- a/apps/01-cloudnative-pg/cluster.yaml
+++ b/apps/01-cloudnative-pg/cluster.yaml
@@ -18,6 +18,7 @@ metadata:
   name: postgresql-cluster
   labels:
     app.kubernetes.io/instance: '{{ app_name }}'
+    wait-for-deployment: Ready
 spec:
   instances: 3
 

--- a/apps/01-cloudnative-pg/cluster.yaml
+++ b/apps/01-cloudnative-pg/cluster.yaml
@@ -16,6 +16,8 @@ apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   name: postgresql-cluster
+  labels:
+    app.kubernetes.io/instance: '{{ app_name }}'
 spec:
   instances: 3
 

--- a/roles/app-installer/tasks/install_app.yaml
+++ b/roles/app-installer/tasks/install_app.yaml
@@ -30,9 +30,9 @@
         msg: "No kustomization.yaml file found in {{ app_dir }}. Documentation available at https://github.com/RS-PYTHON/rs-infra-core/blob/develop/docs/installation.md"
       when: not kustomization_file.stat.exists
 
-    - name: "{{ package_name }} - {{ app_name }} | Include vars from kustomization.yaml"
+    - name: "{{ package_name }} - {{ app_name }} | Include vars from {{ kustomization_file.stat.path }}"
       include_vars:
-        file: "{{ app_dir }}/kustomization.yaml"
+        file: "{{ kustomization_file.stat.path }}"
         name: kustomization
       delegate_to: bastion
 
@@ -124,6 +124,7 @@
         {% endif %} \
         --server-side \
         --force-conflicts \
+        -o yaml \
         -l app.kubernetes.io/instance={{ app_name }}
       register: result
       delegate_to: bastion
@@ -142,15 +143,39 @@
 
     - name: "{{ package_name }} - {{ app_name }} | Extract deployed resources"
       set_fact:
-        resources: "{{ resources|d([]) + [item.split()[0]] }}"
-      loop: "{{ result.stdout_lines }}"
+        # cleanup the yaml to fix invalid CRD definitions before parsing
+        resources: >-
+          {{
+            result.stdout
+            | regex_replace('(?m)^([ ]*)- =$' , '\1- "="')
+            | regex_replace('(?m)^([ ]*)- =~$', '\1- "=~"')
+            | from_yaml_all
+            | list
+          }}
       delegate_to: bastion
 
     - name: "{{ package_name }} - {{ app_name }} | Collect deployed resources and write them into resources.txt"
       copy:
-        content: "{{ resources | join(' ') }}"
+        content: "{{ resources }}"
         dest: "{{ app_dir }}/resources.txt"
       delegate_to: bastion
+
+    - name: "{{ package_name }} - {{ app_name }} | Wait for deployed resources readiness (when asked)"
+      include_tasks: wait_ready.yaml
+      args:
+        apply:
+          delegate_to: bastion
+      # kubectl apply -o yaml does not produce the exact same output when applying one resource or several ones
+      # make sure our resources list handles all cases
+      loop: >-
+        {{
+          resources
+          | map('community.general.json_query', "items || [@]")
+          | flatten
+          | list
+        }}
+      loop_control:
+        label: "{{ item.kind }}/{{ item.metadata.name }}"
 
     - name: "{{ package_name }} - {{ app_name }} | Detect jobs for this app"
       kubernetes.core.k8s_info:
@@ -214,6 +239,11 @@
       delegate_to: bastion
 
   rescue:
+    - name: "{{ package_name }} - {{ app_name }} | Show resources"
+      debug:
+        var: resources
+      when: resources | length > 0
+
     - name: "{{ package_name }} - {{ app_name }} | Show jobs status"
       debug:
         var: jobs.resources

--- a/roles/app-installer/tasks/wait_ready.yaml
+++ b/roles/app-installer/tasks/wait_ready.yaml
@@ -1,0 +1,29 @@
+# Copyright 2025 CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: "{{ package_name }} - {{ app_name }} | Wait for {{ item.kind }} {{ item.metadata.name }} readiness (if asked)"
+  kubernetes.core.k8s_info:
+    api_version: "{{ item.apiVersion }}"
+    kind: "{{ item.kind }}"
+    name: "{{ item.metadata.name }}"
+    namespace: "{{ item.metadata.namespace }}"
+    wait: true
+    wait_sleep: 1
+    wait_timeout: 180
+    wait_condition:
+      type: "{{ item.metadata.labels['wait-for-deployment'] }}"
+  when:
+    - not ansible_check_mode
+    - item.metadata.labels['wait-for-deployment'] is defined
+  delegate_to: bastion


### PR DESCRIPTION
- Wait for Cluster to be ready, via a new dedicated wait-for-deployment label that can be added to other applications too
- Add expected label on postgresql replica pods so that the CI actually waits for them to be ready
- Align the version of grafana-operator CRDs with the one in rs-infra-monitoring
