### PR TITLE
Ignore Helm tests when deploying an app

### DIFF
--- a/roles/app-installer/tasks/install_app.yaml
+++ b/roles/app-installer/tasks/install_app.yaml
@@ -96,6 +96,7 @@
     - name: "{{ package_name }} - {{ app_name }} | Deploy resources"
       shell: |
         kustomize build --enable-helm {{ resources_dir.path }} \
+        | yq eval 'select(.metadata.annotations."helm.sh/hook" != "test")' - \
                 {% if private_registry | bool %} \
         | sed -E '/image:/ {
           /image: (docker.io\/)?([a-z0-9\-]+\/[a-z0-9\-]+)(:[^@ ]+)?(@sha256:[a-f0-9]{64})?/ {


### PR DESCRIPTION
As we don't use helm install to deploy the charts, but kubectl on all resources, we actually deploy the helm tests when present.

This makes us install the [apikeymanager tests](https://github.com/csgroup-oss/apikey-manager/tree/main/deploy/helm/apikeymanager/templates/tests) every time, while we don't want to do that.

This PR ignores the label found in helm tests to skip these deployments.