### PR TITLE
Add wait-for-deployment label to Keycloak, KeycloakRealmImport

### DIFF
--- a/apps/05-keycloak/keycloak.yaml
+++ b/apps/05-keycloak/keycloak.yaml
@@ -16,6 +16,8 @@ apiVersion: k8s.keycloak.org/v2alpha1
 kind: Keycloak
 metadata:
   name: keycloak
+  labels:
+    wait-for-deployment: Ready
 spec:
   db:
     vendor: postgres

--- a/apps/05-keycloak/keycloakrealmimport.yaml
+++ b/apps/05-keycloak/keycloakrealmimport.yaml
@@ -17,6 +17,8 @@ kind: KeycloakRealmImport
 metadata:
   name: rspy
   namespace: iam
+  labels:
+    wait-for-deployment: Done
 spec:
   keycloakCRName: keycloak
   realm:

--- a/roles/app-installer/tasks/install_app.yaml
+++ b/roles/app-installer/tasks/install_app.yaml
@@ -183,7 +183,7 @@
         }}
       loop_control:
         label: "{{ item.kind }}/{{ item.metadata.name }}"
-      when: item.kind in ['Job', 'Pod', 'Deployment', 'StatefulSet', 'DaemonSet', 'Cluster', 'ScheduledBackup']
+      when: item.kind in ['Job', 'Pod', 'Deployment', 'StatefulSet', 'DaemonSet', 'Cluster', 'ScheduledBackup', 'Keycloak', 'KeycloakRealmImport']
 
     - name: "{{ package_name }} - {{ app_name }} | Detect jobs for this app"
       kubernetes.core.k8s_info:

--- a/roles/app-installer/tasks/wait_ready.yaml
+++ b/roles/app-installer/tasks/wait_ready.yaml
@@ -37,7 +37,7 @@
         wait_condition:
           type: "{{ item.metadata.labels['wait-for-deployment'] }}"
       when:
-        - item.kind == 'Cluster'
+        - item.kind in ['Cluster', 'Keycloak', 'KeycloakRealmImport']
 
     - name: Wait using condition for ScheduledBackup
       block:
@@ -102,7 +102,7 @@
           type: Established
       when: item.kind == 'CustomResourceDefinition'
 
-  when: 
+  when:
     - not ansible_check_mode
     - item.metadata.labels['wait-for-deployment'] is defined
   delegate_to: bastion


### PR DESCRIPTION
Make sure we wait for Keycloak realm import to be done before installing oauth2-proxy:

```
Tue, 30 Sep 2025 13:54:30 GMT TASK [app-installer : apps - keycloak | Wait for deployed resources readiness (when asked)] ***
Tue, 30 Sep 2025 13:54:30 GMT skipping: [localhost] => (item=Secret/keycloak-database-password) 
Tue, 30 Sep 2025 13:54:30 GMT skipping: [localhost] => (item=ServiceMonitor/keycloak) 
Tue, 30 Sep 2025 13:54:30 GMT skipping: [localhost] => (item=Ingress/keycloak) 
Tue, 30 Sep 2025 13:54:30 GMT included: /home/runner/work/rs-infra-core/rs-infra-core/roles/app-installer/tasks/wait_ready.yaml for localhost => (item=Keycloak/keycloak)
Tue, 30 Sep 2025 13:54:30 GMT included: /home/runner/work/rs-infra-core/rs-infra-core/roles/app-installer/tasks/wait_ready.yaml for localhost => (item=KeycloakRealmImport/rspy)
Tue, 30 Sep 2025 13:54:30 GMT TASK [app-installer : Wait using condition for "Keycloak"] *********************
Tue, 30 Sep 2025 13:55:04 GMT ok: [localhost -> bastion(127.0.0.1)]
Tue, 30 Sep 2025 13:55:04 GMT TASK [app-installer : Wait using condition for "KeycloakRealmImport"] **********
Tue, 30 Sep 2025 13:55:46 GMT ok: [localhost -> bastion(127.0.0.1)]
```