### PR TITLE
update template for R3-64 on dask-worker-on-demand-rspython-ops

### DIFF
--- a/roles/terraform/cluster/tasks/cluster.tf
+++ b/roles/terraform/cluster/tasks/cluster.tf
@@ -213,7 +213,7 @@ resource "ovh_cloud_project_kube_nodepool" "nodepool_dask_scheduler" {
 resource "ovh_cloud_project_kube_nodepool" "nodepool_dask_worker_on_demand" {
   kube_id       = ovh_cloud_project_kube.cluster.id
   name          = "dask-worker-on-demand-${var.cluster_name}"
-  flavor_name   = "b3-16"
+  flavor_name   = "r3-64"
   desired_nodes = var.nodepool_dask_worker_on_demand_desired_nodes
   min_nodes     = 0
   max_nodes     = 8


### PR DESCRIPTION
With this template All processors should be able to use same node pool.
