### PR TITLE
Fix node label configuration script

### DIFF
--- a/.github/common/resources/configure-cluster.sh
+++ b/.github/common/resources/configure-cluster.sh
@@ -34,7 +34,8 @@ read -r -a SUBDOMAINS <<< "$SUBDOMAINS_INPUT"
 
 # --- Label the minikube node ---
 echo "🏷️  Applying labels to node 'minikube': $LABELS_INPUT"
-kubectl label node minikube "$LABELS_INPUT"
+read -r -a LABELS <<< "$LABELS_INPUT"
+kubectl label node minikube "${LABELS[@]}"
 
 # --- Extract domain and IP
 DOMAIN=$(yq e '.platform_domain_name' ./inventory/sample/host_vars/setup/main.yaml)


### PR DESCRIPTION
This fixes an error when calling the script with multiple labels (needed for rs-workflow-env)