### PR TITLE
Cache Miniforge and Conda env to speedup cicd

### DIFF
--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -32,7 +32,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install requirements
+      - name: Cache Miniforge and Conda env
+        id: cache-conda
+        uses: actions/cache@v4
+        with:
+          path: ~/miniforge3
+          key: conda-${{ runner.os }}-${{ hashFiles('.github/common/resources/install-requirements.sh') }}
+          restore-keys: |
+            conda-${{ runner.os }}-
+      - name: Install requirements (if cache missed)
+        if: steps.cache-conda.outputs.cache-hit != 'true'
         run: |
           .github/common/resources/install-requirements.sh
         shell: bash


### PR DESCRIPTION
This should save between 1m 30s and 2m 15s on all worklow runs:

https://github.com/RS-PYTHON/rs-infra-core/actions/runs/18836970522/job/53740072296 took 2m 9s to install requirements then 4s to cache folder
https://github.com/RS-PYTHON/rs-infra-core/actions/runs/18837555574/job/53741974247 took only 4s to restore folder