### PR TITLE
Fix catalog database username

### DIFF
--- a/inventory/sample/host_vars/setup/apps.yml
+++ b/inventory/sample/host_vars/setup/apps.yml
@@ -184,7 +184,7 @@ rs_server_catalog:
     host: cnpgstac-rw.database.svc.cluster.local
     name: catalog
     password: password
-    username: postgres
+    username: catalog
 
 rs_server_catalog_db:
   stac:


### PR DESCRIPTION
Otherwise cnpg tries to use superuser postgres when creating and accessing the catalog database, with wrong password