### PR TITLE
Remove '*' for allowed special characters in random passwords

### DIFF
--- a/inventory/sample/host_vars/setup/apps.yml
+++ b/inventory/sample/host_vars/setup/apps.yml
@@ -513,33 +513,33 @@ neuvector:
   core:
     admin:
       Fullname: "admin"
-      Password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.*+?-', length=30) }}"
+      Password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.+?-', length=30) }}"
     exporter:
       Fullname: "exporter"
-      Password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.*+?-', length=30) }}"
+      Password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.+?-', length=30) }}"
     secops:
       Fullname: "rspysecopsadm"
-      Password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.*+?-', length=30) }}"
+      Password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.+?-', length=30) }}"
     secret: neuvector-init
   exporter:
     host: neuvector-svc-controller-api.svc.cluster.local
     CTRL_USERNAME: exporter
-    CTRL_PASSWORD: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.*+?-', length=30) }}"
+    CTRL_PASSWORD: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.+?-', length=30) }}"
     secret: exporter
 
 wazuh:
   server:
     kibanaserver:
       username: "kibanaserver"
-      password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.*+?-', length=30) }}"
+      password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.+?-', length=30) }}"
       secret: dashboard-cred
     admin:
       username: "admin"
-      password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.*+?-', length=30) }}"
+      password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.+?-', length=30) }}"
       secret: indexer-cred
     api:
       username: "wazuh-wui"
-      password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.*+?-', length=30) }}"
+      password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.+?-', length=30) }}"
       secret: wazuh-api-cred
     clusterkey:
       key: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_numeric=1, special=false, length=32) }}"


### PR DESCRIPTION
As the passwords are then used in ansible yaml files, it cause yaml error when it is wrongly interpreted as an anchor reference:

```
fatal: [localhost -> bastion(127.0.0.1)]: FAILED! => {"changed": true, "cmd": "kustomize build --enable-helm /tmp/ansible._3gw6_yzk8s_resources_wazuh-server | yq eval 'select(.metadata.annotations.\"helm.sh/hook\" != \"test\" and .metadata.annotations.\"helm.sh/hook\" != \"test-success\")' -  | sed -E '/image:/ {\n  /image: (docker.io\\/)?([a-z0-9\\-]+\\/[a-z0-9\\-]+)(:[^@ ]+)?(@sha256:[a-f0-9]{64})?/ {\n    s|image: (docker.io\\/)?([a-z0-9\\-]+\\/[a-z0-9\\-]+)(:[^@ ]+)?(@sha256:[a-f0-9]{64})?|image: example.com/proxycache/\\2\\3\\4|\n    b\n  }\n  /^image: [a-z0-9\\-]+\\/[a-z0-9\\-]+(:[^@ ]+)?(@sha256:[a-f0-9]{64})?$/ {\n    s|^image: ([a-z0-9\\-]+\\/[a-z0-9\\-]+)(:[^@ ]+)?(@sha256:[a-f0-9]{64})?|image: example.com/proxycache/\\1\\2\\3|\n    b\n  }\n  /^image: [a-z0-9\\-]+(:[^@ ]+)?(@sha256:[a-f0-9]{64})?$/ {\n    s|^image: ([a-z0-9\\-]+)(:[^@ ]+)?(@sha256:[a-f0-9]{64})?|image: example.com/proxycache/\\1\\2\\3|\n  }\n}' | yq eval 'select(.kind == \"Pod\") |= .spec.imagePullSecrets += [{\"name\": \"harbor-pull-secret\"}] |\n    select(.kind == \"Deployment\") |= .spec.template.spec.imagePullSecrets += [{\"name\": \"harbor-pull-secret\"}] |\n    select(.kind == \"StatefulSet\") |= .spec.template.spec.imagePullSecrets += [{\"name\": \"harbor-pull-secret\"}] |\n    select(.kind == \"DaemonSet\") |= .spec.template.spec.imagePullSecrets += [{\"name\": \"harbor-pull-secret\"}] |\n    select(.kind == \"Job\") |= .spec.template.spec.imagePullSecrets += [{\"name\": \"harbor-pull-secret\"}] |\n    select(.kind == \"CronJob\") |= .spec.jobTemplate.spec.template.spec.imagePullSecrets += [{\"name\": \"harbor-pull-secret\"}] |\n    select(.kind == \"ReplicaSet\") |= .spec.template.spec.imagePullSecrets += [{\"name\": \"harbor-pull-secret\"}]' -  | kubectl apply -f -   --dry-run=server  --server-side --force-conflicts -o yaml -l app.kubernetes.io/instance=wazuh-server\n", "delta": "0:00:01.851799", "end": "2025-10-29 15:23:45.742807", "msg": "non-zero return code", "rc": 1, "start": "2025-10-29 15:23:43.891008", "stderr": "Error: accumulating resources: accumulating resources from 'secrets.yaml': MalformedYAMLError: yaml: unknown anchor 'neSRXN6hamp6yLDifEh' referenced in File: secrets.yaml\nerror: no objects passed to apply", "stderr_lines": ["Error: accumulating resources: accumulating resources from 'secrets.yaml': MalformedYAMLError: yaml: unknown anchor 'neSRXN6hamp6yLDifEh' referenced in File: secrets.yaml", "error: no objects passed to apply"], "stdout": "", "stdout_lines": []}
```