### PR TITLE
Retry pulling helm chart in case of timeouts

### DIFF
--- a/roles/app-installer/tasks/install_app.yaml
+++ b/roles/app-installer/tasks/install_app.yaml
@@ -134,10 +134,7 @@
       delay: 15
       until: >
         (result.rc == 0) or
-        ('503' not in result.stderr and
-        '502' not in result.stderr and
-        '500' not in result.stderr and
-        'Service Unavailable' not in result.stderr)
+        (result.stderr is search('500|502|503|Service Unavailable|timeout|timed out|deadline exceeded|Client.Timeout'))
 
     - name: "{{ package_name }} - {{ app_name }} | reset facts"
       set_fact:


### PR DESCRIPTION
To retry when facing this kind of errors from github:

```yaml
{
  "attempts": 1,
  "changed": true,
  "cmd": "kustomize build --enable-helm /tmp/ansible.fpk2sr0wk8s_resources_apikeymanager |
          yq eval 'select(.metadata.annotations.\"helm.sh/hook\" != \"test\"
                         and .metadata.annotations.\"helm.sh/hook\" != \"test-success\")' - |
          kubectl apply -f - --dry-run=server --server-side --force-conflicts
          -o yaml -l app.kubernetes.io/instance=apikeymanager",
  "delta": "0:02:00.221631",
  "end": "2025-11-24 16:30:10.885227",
  "msg": "non-zero return code",
  "rc": 1,
  "start": "2025-11-24 16:28:10.663596",
  "stderr": "Error:
    Error: Get
    \"https://github.com/csgroup-oss/apikey-manager/releases/download/1.0.0/apikeymanager-1.0.0.tgz\":
    context deadline exceeded (Client.Timeout exceeded while awaiting headers)

    unable to run:
      'helm pull --untar
                  --untardir /tmp/ansible.fpk2sr0wk8s_resources_apikeymanager/charts/apikeymanager-1.0.0
                  --repo https://csgroup-oss.github.io/apikey-manager/
                  apikeymanager --version 1.0.0'
    with env=[
      HELM_CONFIG_HOME=/tmp/kustomize-helm-3406457951/helm
      HELM_CACHE_HOME=/tmp/kustomize-helm-3406457951/helm/.cache
      HELM_DATA_HOME=/tmp/kustomize-helm-3406457951/helm/.data
    ]
    (is 'helm' installed?): exit status 1

    error: no objects passed to apply",
  "stdout": ""
}
```