### PR TITLE
Revert to kubernetes-client 1.33.0 to avoid kustomize 5.8.0

### DIFF
--- a/.github/common/resources/install-requirements.sh
+++ b/.github/common/resources/install-requirements.sh
@@ -30,6 +30,9 @@ conda update -n base -c defaults conda
 conda create -y -n rspy python=3.11
 
 # Install Ansible, Terraform, Openstackclient
-conda run -n rspy conda install -y -c conda-forge ansible terraform python-openstackclient passlib boto3 "kubernetes-helm<4" kubernetes-client python-kubernetes "bcrypt<5"
+# DO NOT INSTALL THESE VERSIONS:
+# - kubernetes-helm 4.0 - see https://github.com/kubernetes-sigs/kustomize/issues/6013
+# - kubernetes-client 1.34.0 - see https://github.com/kubernetes-sigs/kustomize/issues/6014 - https://github.com/kubernetes-sigs/kustomize/issues/6027 - https://github.com/kubernetes-sigs/kustomize/issues/6031
+conda run -n rspy conda install -y -c conda-forge ansible terraform python-openstackclient passlib boto3 "kubernetes-helm<4" "kubernetes-client<1.34.0" python-kubernetes "bcrypt<5"
 
 conda run -n rspy ansible-galaxy collection install openstack.cloud amazon.aws kubernetes.core community.general


### PR DESCRIPTION
Kustomize 5.8.0 simply doesn't work, see all the namespace issues:
- https://github.com/kubernetes-sigs/kustomize/issues/6014
- https://github.com/kubernetes-sigs/kustomize/issues/6027
- https://github.com/kubernetes-sigs/kustomize/issues/6031