### PR TITLE
Update to cert-manager 1.19.2

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -10,13 +10,13 @@ Below are all the FOSS (Free and open-source software) used and their respective
 
 - Cert manager :
   - Helm chart
-    - Version: v1.19.1
-    - License: [Apache License 2.0](https://github.com/cert-manager/cert-manager/blob/v1.19.1/LICENSE)
-    - Source: <https://github.com/cert-manager/cert-manager/tree/v1.19.1/deploy/charts/cert-manager>
+    - Version: v1.19.2
+    - License: [Apache License 2.0](https://github.com/cert-manager/cert-manager/blob/v1.19.2/LICENSE)
+    - Source: <https://github.com/cert-manager/cert-manager/tree/v1.19.2/deploy/charts/cert-manager>
     - Copyright: Copyright The cert-manager Authors. [Authors and Contributors](https://github.com/cert-manager/cert-manager/blob/v1.6.1/deploy/charts/cert-manager/OWNERS)
   - Container image(s)
-    - quay.io/jetstack/cert-manager-cainjector:v1.19.1
-      - License: [Apache License 2.0](https://github.com/cert-manager/cert-manager/blob/v1.19.1/LICENSE)
+    - quay.io/jetstack/cert-manager-cainjector:v1.19.2
+      - License: [Apache License 2.0](https://github.com/cert-manager/cert-manager/blob/v1.19.2/LICENSE)
 
 - NGINX Ingress Controller :
   - Helm chart

--- a/apps/00-crds-cert-manager/kustomization.yaml
+++ b/apps/00-crds-cert-manager/kustomization.yaml
@@ -14,7 +14,7 @@
 
 
 resources:
-- https://github.com/cert-manager/cert-manager/releases/download/v1.19.1/cert-manager.crds.yaml
+- https://github.com/cert-manager/cert-manager/releases/download/v1.19.2/cert-manager.crds.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:

--- a/apps/01-cert-manager/kustomization.yaml
+++ b/apps/01-cert-manager/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://charts.jetstack.io
   valuesFile: values.yaml
-  version: v1.19.1
+  version: v1.19.2
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:


### PR DESCRIPTION
Update to:
- https://github.com/cert-manager/cert-manager/releases/tag/v1.19.2