### PR TITLE
Update to cnpg 1.27.2, postgresql 18.1

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -41,16 +41,16 @@ Below are all the FOSS (Free and open-source software) used and their respective
     - grafana/grafana:10.0.3
       - License: [GNU Affero General Public License v3.0](https://github.com/grafana/grafana/blob/v10.0.3/LICENSE)
 
-- PostgreSQL
+- CloudNativePG
   - Helm chart:
-    - Version: 0.26.0
-    - Licence: [Apache License 2.0](https://github.com/cloudnative-pg/charts/blob/cloudnative-pg-v0.26.0/LICENSE)
-    - Source: <https://github.com/cloudnative-pg/charts/tree/cloudnative-pg-v0.26.0>
+    - Version: 0.27.0
+    - Licence: [Apache License 2.0](https://github.com/cloudnative-pg/charts/blob/cloudnative-pg-v0.27.0/LICENSE)
+    - Source: <https://github.com/cloudnative-pg/charts/tree/cloudnative-pg-v0.27.0>
     - Copyright: Copyright The CloudNativePG authors. [Authors and Contributors](https://github.com/cloudnative-pg/charts/graphs/contributors)
   - Container image(s)
-    - ghcr.io/cloudnative-pg/cloudnative-pg:1.27.0
-      - License: [Apache License 2.0](https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.27.0/LICENSE)
-    - ghcr.io/cloudnative-pg/postgresql:17.5
+    - ghcr.io/cloudnative-pg/cloudnative-pg:1.27.2
+      - License: [Apache License 2.0](https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.27.2/LICENSE)
+    - ghcr.io/cloudnative-pg/postgresql:18.1
       - License: [Apache License 2.0](https://github.com/cloudnative-pg/postgres-containers/blob/main/LICENSE)
 
 - Loki

--- a/apps/00-crds-cloudnative-pg/kustomization.yaml
+++ b/apps/00-crds-cloudnative-pg/kustomization.yaml
@@ -14,17 +14,17 @@
 
 
 resources:
-- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.0/config/crd/bases/postgresql.cnpg.io_clusters.yaml
-- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.0/config/crd/bases/postgresql.cnpg.io_backups.yaml
-- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.0/config/crd/bases/postgresql.cnpg.io_scheduledbackups.yaml
-- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.0/config/crd/bases/postgresql.cnpg.io_poolers.yaml
-- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.0/config/crd/bases/postgresql.cnpg.io_imagecatalogs.yaml
-- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.0/config/crd/bases/postgresql.cnpg.io_clusterimagecatalogs.yaml
-- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.0/config/crd/bases/postgresql.cnpg.io_databases.yaml
-- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.0/config/crd/bases/postgresql.cnpg.io_publications.yaml
-- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.0/config/crd/bases/postgresql.cnpg.io_subscriptions.yaml
-- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.0/config/crd/bases/postgresql.cnpg.io_failoverquorums.yaml
-- https://raw.githubusercontent.com/cloudnative-pg/plugin-barman-cloud/refs/tags/v0.6.0/config/crd/bases/barmancloud.cnpg.io_objectstores.yaml
+- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.2/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.2/config/crd/bases/postgresql.cnpg.io_backups.yaml
+- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.2/config/crd/bases/postgresql.cnpg.io_scheduledbackups.yaml
+- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.2/config/crd/bases/postgresql.cnpg.io_poolers.yaml
+- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.2/config/crd/bases/postgresql.cnpg.io_imagecatalogs.yaml
+- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.2/config/crd/bases/postgresql.cnpg.io_clusterimagecatalogs.yaml
+- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.2/config/crd/bases/postgresql.cnpg.io_databases.yaml
+- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.2/config/crd/bases/postgresql.cnpg.io_publications.yaml
+- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.2/config/crd/bases/postgresql.cnpg.io_subscriptions.yaml
+- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/tags/v1.27.2/config/crd/bases/postgresql.cnpg.io_failoverquorums.yaml
+- https://raw.githubusercontent.com/cloudnative-pg/plugin-barman-cloud/refs/tags/v0.9.0/config/crd/bases/barmancloud.cnpg.io_objectstores.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:

--- a/apps/02-plugin-cloudnative-pg/kustomization.yaml
+++ b/apps/02-plugin-cloudnative-pg/kustomization.yaml
@@ -23,4 +23,4 @@ labels:
     app.kubernetes.io/instance: '{{ app_name }}'
     wait-for-deployment: Ready
 resources:
-- https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v0.6.0/manifest.yaml
+- https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v0.9.0/manifest.yaml

--- a/apps/03-cloudnative-pg/kustomization.yaml
+++ b/apps/03-cloudnative-pg/kustomization.yaml
@@ -20,7 +20,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://cloudnative-pg.io/charts/
   valuesFile: values.yaml
-  version: 0.26.0
+  version: 0.27.0
 
 resources:
 - cluster.yaml

--- a/apps/04-keycloak-db/database.yaml
+++ b/apps/04-keycloak-db/database.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: create-keycloak-db
-        image: ghcr.io/cloudnative-pg/postgresql:17.5
+        image: ghcr.io/cloudnative-pg/postgresql:18.1
         command: ["/scripts/create-database.sh"]
         volumeMounts:
           - name: create-database


### PR DESCRIPTION
Update to:
- https://github.com/cloudnative-pg/cloudnative-pg/releases/tag/v1.27.1
- https://github.com/cloudnative-pg/cloudnative-pg/releases/tag/v1.27.2
- https://github.com/cloudnative-pg/plugin-barman-cloud/releases/tag/v0.9.0

Should we use https://github.com/cloudnative-pg/charts/tree/main/charts/plugin-barman-cloud instead of using directly https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v0.9.0/manifest.yaml?