### PR TITLE
Fix Grafana deployment with private repository

### DIFF
--- a/roles/app-installer/tasks/install_app.yaml
+++ b/roles/app-installer/tasks/install_app.yaml
@@ -117,6 +117,7 @@
             select(.kind == "DaemonSet") |= .spec.template.spec.imagePullSecrets += [{"name": "harbor-pull-secret"}] |
             select(.kind == "Job") |= .spec.template.spec.imagePullSecrets += [{"name": "harbor-pull-secret"}] |
             select(.kind == "CronJob") |= .spec.jobTemplate.spec.template.spec.imagePullSecrets += [{"name": "harbor-pull-secret"}] |
+            select(.kind == "Grafana") |= .spec.deployment.spec.template.spec.imagePullSecrets += [{"name": "harbor-pull-secret"}] |
             select(.kind == "ReplicaSet") |= .spec.template.spec.imagePullSecrets += [{"name": "harbor-pull-secret"}]' - \
         {% endif %} \
         | kubectl apply -f - \


### PR DESCRIPTION
Missing Secret for Grafana Deployment.
This Deployment has been deployed wiht grafana operator and secret configuration should be added to grafana object.