### PR TITLE
Update to oauth2-proxy helm chart 10.0.1

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -121,9 +121,9 @@ Below are all the FOSS (Free and open-source software) used and their respective
 
 - oauth2-proxy
   - Helm chart:
-    - Version: 9.0.1
-    - Licence: [Apache License 2.0](https://github.com/oauth2-proxy/manifests/blob/oauth2-proxy-9.0.1/LICENSE)
-    - Source: <https://github.com/oauth2-proxy/manifests/tree/oauth2-proxy-9.0.1>
+    - Version: 10.0.1
+    - Licence: [Apache License 2.0](https://github.com/oauth2-proxy/manifests/blob/oauth2-proxy-10.0.1/LICENSE)
+    - Source: <https://github.com/oauth2-proxy/manifests/tree/oauth2-proxy-10.0.1>
     - Copyright: Copyright The oauth2-proxy Development Team. [Authors and Contributors](https://github.com/oauth2-proxy/manifests/graphs/contributors)
   - Container image(s)
     - quay.io/oauth2-proxy/oauth2-proxy:v7.13.0

--- a/apps/oauth2-proxy/kustomization.yaml
+++ b/apps/oauth2-proxy/kustomization.yaml
@@ -21,7 +21,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://oauth2-proxy.github.io/manifests
   valuesFile: values.yaml
-  version: 9.0.1
+  version: 10.0.1
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:

--- a/apps/oauth2-proxy/values.yaml
+++ b/apps/oauth2-proxy/values.yaml
@@ -54,7 +54,7 @@ sessionStorage:
   type: redis
   redis:
     clientType: "standalone"
-redis:
+redis-ha:
   enabled: true
   replicas: 1
   redis:


### PR DESCRIPTION
Update to:
- https://github.com/oauth2-proxy/manifests/releases/tag/oauth2-proxy-10.0.0
- https://github.com/oauth2-proxy/manifests/releases/tag/oauth2-proxy-10.0.1