### PR TITLE
Update to terraform-provider-random 3.8.0

### DIFF
--- a/roles/terraform/registry/tasks/provider.tf
+++ b/roles/terraform/registry/tasks/provider.tf
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.6"
+      version = "~> 3.8.0"
     }
     ovh = {
       source  = "ovh/ovh"


### PR DESCRIPTION
Update to:
- https://github.com/hashicorp/terraform-provider-random/releases/tag/v3.7.0
- https://github.com/hashicorp/terraform-provider-random/releases/tag/v3.7.1
- https://github.com/hashicorp/terraform-provider-random/releases/tag/v3.7.2
- https://github.com/hashicorp/terraform-provider-random/releases/tag/v3.8.0