### PR TITLE
Update to ingress-nginx 1.14.1

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -20,15 +20,15 @@ Below are all the FOSS (Free and open-source software) used and their respective
 
 - NGINX Ingress Controller :
   - Helm chart
-    - Version: v4.12.1
-    - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.12.1/LICENSE)
-    - Source: <https://github.com/kubernetes/ingress-nginx/tree/helm-chart-4.12.1/charts/ingress-nginx>
-    - Copyright: Copyright The ingress-nginx Authors. Authors and Contributors [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.12.1/OWNERS) and [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.12.1/OWNERS_ALIASES)
+    - Version: v4.14.1
+    - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.14.1/LICENSE)
+    - Source: <https://github.com/kubernetes/ingress-nginx/tree/helm-chart-4.14.1/charts/ingress-nginx>
+    - Copyright: Copyright The ingress-nginx Authors. Authors and Contributors [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.14.1/OWNERS) and [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.14.1/OWNERS_ALIASES)
   - Container image(s)
-    - registry.k8s.io/ingress-nginx/controller:v1.12.1
-      - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/controller-v1.12.1/LICENSE)
-    - docker.io/library/nginx:1.25.5-alpine
-      - License: [BSD 2-Clause "Simplified" License](https://github.com/nginxinc/docker-nginx/blob/1.25.5/LICENSE)
+    - registry.k8s.io/ingress-nginx/controller:v1.14.1
+      - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/controller-v1.14.1/LICENSE)
+    - docker.io/library/nginx:1.27.1-alpine
+      - License: [BSD 2-Clause "Simplified" License](https://github.com/nginxinc/docker-nginx/blob/1.27.1/LICENSE)
 
 - Grafana Operator
   - Helm chart: *None*

--- a/apps/03-ingress-nginx/kustomization.yaml
+++ b/apps/03-ingress-nginx/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://kubernetes.github.io/ingress-nginx
   valuesFile: values.yaml
-  version: v4.12.1
+  version: v4.14.1
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:


### PR DESCRIPTION
Update helm chart to:
- https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.13.0
- https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.14.0
- https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.14.1

Update ingress-nginx to:
- https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.13.0
- https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.14.0
- https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.14.1
