### PR TITLE
RSPY-923 - Update to terraform-provider-ovh 2.11.0

### DIFF
--- a/roles/terraform/cluster/tasks/main.tf
+++ b/roles/terraform/cluster/tasks/main.tf
@@ -28,7 +28,7 @@ terraform {
 
     ovh = {
       source  = "ovh/ovh"
-      version = "1.4.0"
+      version = "2.11.0"
     }
   }
   backend "s3" {

--- a/roles/terraform/registry/tasks/provider.tf
+++ b/roles/terraform/registry/tasks/provider.tf
@@ -21,7 +21,7 @@ terraform {
     }
     ovh = {
       source  = "ovh/ovh"
-      version = "1.6.0"
+      version = "2.11.0"
     }
   }
 }


### PR DESCRIPTION
Update to:
- https://github.com/ovh/terraform-provider-ovh/releases/tag/v2.11.0