### PR TITLE
Update to ingress-nginx 1.14.3

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -20,13 +20,13 @@ Below are all the FOSS (Free and open-source software) used and their respective
 
 - NGINX Ingress Controller
   - Helm chart
-    - Version: v4.14.1
-    - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.14.1/LICENSE)
-    - Source: <https://github.com/kubernetes/ingress-nginx/tree/helm-chart-4.14.1/charts/ingress-nginx>
-    - Copyright: Copyright The ingress-nginx Authors. Authors and Contributors [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.14.1/OWNERS) and [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.14.1/OWNERS_ALIASES)
+    - Version: v4.14.3
+    - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.14.3/LICENSE)
+    - Source: <https://github.com/kubernetes/ingress-nginx/tree/helm-chart-4.14.3/charts/ingress-nginx>
+    - Copyright: Copyright The ingress-nginx Authors. Authors and Contributors [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.14.3/OWNERS) and [here](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.14.3/OWNERS_ALIASES)
   - Container image(s)
-    - registry.k8s.io/ingress-nginx/controller:v1.14.1
-      - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/controller-v1.14.1/LICENSE)
+    - registry.k8s.io/ingress-nginx/controller:v1.14.3
+      - License: [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/controller-v1.14.3/LICENSE)
     - docker.io/library/nginx:1.27.1-alpine
       - License: [BSD 2-Clause "Simplified" License](https://github.com/nginxinc/docker-nginx/blob/1.27.0/LICENSE)
 

--- a/apps/03-ingress-nginx/kustomization.yaml
+++ b/apps/03-ingress-nginx/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://kubernetes.github.io/ingress-nginx
   valuesFile: values.yaml
-  version: v4.14.1
+  version: v4.14.3
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:


### PR DESCRIPTION
Update helm chart to:
- https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.14.2
- https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.14.3

Update ingress-nginx to:
- https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.14.2
- https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.14.3
