### PR TITLE
Update to oauth2-proxy 10.1.4 / 7.14.2

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -63,13 +63,13 @@ Below are all the FOSS (Free and open-source software) used and their respective
 
 - oauth2-proxy
   - Helm chart
-    - Version: 10.1.2
-    - Licence: [Apache License 2.0](https://github.com/oauth2-proxy/manifests/blob/oauth2-proxy-10.1.2/LICENSE)
-    - Source: <https://github.com/oauth2-proxy/manifests/tree/oauth2-proxy-10.1.2>
+    - Version: 10.1.4
+    - Licence: [Apache License 2.0](https://github.com/oauth2-proxy/manifests/blob/oauth2-proxy-10.1.4/LICENSE)
+    - Source: <https://github.com/oauth2-proxy/manifests/tree/oauth2-proxy-10.1.4>
     - Copyright: Copyright The oauth2-proxy Development Team. [Authors and Contributors](https://github.com/oauth2-proxy/manifests/graphs/contributors)
   - Container image(s)
-    - quay.io/oauth2-proxy/oauth2-proxy:v7.13.0
-      - License: [MIT License](https://github.com/oauth2-proxy/oauth2-proxy/blob/v7.13.0/LICENSE)
+    - quay.io/oauth2-proxy/oauth2-proxy:v7.14.2
+      - License: [MIT License](https://github.com/oauth2-proxy/oauth2-proxy/blob/v7.14.2/LICENSE)
 
 - kube-prometheus-stack
   - Custom Resource Definitions

--- a/apps/oauth2-proxy/kustomization.yaml
+++ b/apps/oauth2-proxy/kustomization.yaml
@@ -21,7 +21,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://oauth2-proxy.github.io/manifests
   valuesFile: values.yaml
-  version: 10.1.2
+  version: 10.1.4
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:


### PR DESCRIPTION
Update helm chart to:
- https://github.com/oauth2-proxy/manifests/releases/tag/oauth2-proxy-10.1.3
- https://github.com/oauth2-proxy/manifests/releases/tag/oauth2-proxy-10.1.4

Update oauth2-proxy to:
- https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.14.0
- https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.14.1
- https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.14.2