### PR TITLE
Use OCI Registry for cert-manager

### DIFF
--- a/apps/01-cert-manager/kustomization.yaml
+++ b/apps/01-cert-manager/kustomization.yaml
@@ -17,7 +17,7 @@ helmCharts:
 - name: cert-manager
   namespace: kube-system
   releaseName: '{{ app_name }}'
-  repo: https://charts.jetstack.io
+  repo: oci://quay.io/jetstack/charts
   valuesFile: values.yaml
   version: v1.19.3
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
According to https://cert-manager.io/docs/installation/helm/:

> cert-manager is available as an OCI Helm chart and from a Helm repository. **We recommend using the OCI Helm chart for any recent version of cert-manager**.
> 
> **The OCI Helm charts are the source of truth** and are published immediately upon release. The legacy HTTP Helm repository at https://charts.jetstack.io is updated a few hours after the OCI charts are published.