### PR TITLE
Lower the length of hashed passwords to 24 characters

### DIFF
--- a/inventory/sample/host_vars/setup/apps.yml
+++ b/inventory/sample/host_vars/setup/apps.yml
@@ -556,11 +556,11 @@ wazuh:
   server:
     kibanaserver:
       username: "kibanaserver"
-      password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.+?-', length=30) }}"
+      password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.+?-', length=24) }}"
       secret: dashboard-cred
     admin:
       username: "admin"
-      password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.+?-', length=30) }}"
+      password: "{{ lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='.+?-', length=24) }}"
       secret: indexer-cred
     api:
       username: "wazuh-wui"


### PR DESCRIPTION
So that even if all characters take up to three bytes we stay below the bcrypt limit of 72 bytes

Currently we can still face this error:

```
changed: [localhost -> bastion(127.0.0.1)] => (item=/home/runner/work/rs-config/rs-config/rs-config/apps-security/01-wazuh-server/sp-metadata.xml.saml)
[ERROR]: Task failed: The filter plugin 'ansible.builtin.password_hash' failed: Could not hash the secret: password cannot be longer than 72 bytes, truncate manually if necessary (e.g. my_password[:72])

Task failed.
Origin: /home/runner/work/rs-config/rs-config/roles/app-installer/tasks/install_app.yaml:59:7

57       check_mode: false
58
59     - name: "{{ package_name }} - {{ app_name }} | Template and send resources to remote"
         ^ column 7

<<< caused by >>>

The filter plugin 'ansible.builtin.password_hash' failed: Could not hash the secret: password cannot be longer than 72 bytes, truncate manually if necessary (e.g. my_password[:72])
Origin: /home/runner/work/rs-config/rs-config/rs-config/apps-security/01-wazuh-server/internal_users.yml

failed: [localhost -> bastion] (item=/home/runner/work/rs-config/rs-config/rs-config/apps-security/01-wazuh-server/internal_users.yml) => {"ansible_loop_var": "item", "changed": false, "item": "/home/runner/work/rs-config/rs-config/rs-config/apps-security/01-wazuh-server/internal_users.yml", "msg": "Task failed: The filter plugin 'ansible.builtin.password_hash' failed: Could not hash the secret: password cannot be longer than 72 bytes, truncate manually if necessary (e.g. my_password[:72])"}
```