### PR TITLE
Revert "Update Helm and Kustomize to latest versions"

### DIFF
--- a/.github/common/resources/install-requirements.sh
+++ b/.github/common/resources/install-requirements.sh
@@ -32,6 +32,15 @@ conda update -n base -c defaults conda
 conda create -y -n rspy python=$PYTHON_VERSION
 
 # Install Ansible, Terraform, Openstackclient
-conda run -n rspy conda install -y -c conda-forge ansible terraform python-openstackclient passlib boto3 kubernetes-helm kubernetes-client python-kubernetes bcrypt kustomize
+# DO NOT INSTALL THESE VERSIONS:
+# - kubernetes-helm 4.0 - see https://github.com/kubernetes-sigs/kustomize/issues/6013
+# - kustomize 5.8.0 / 5.8.1 - see:
+#   - https://github.com/kubernetes-sigs/kustomize/issues/6014
+#   - https://github.com/kubernetes-sigs/kustomize/issues/6027
+#   - https://github.com/kubernetes-sigs/kustomize/issues/6031
+#   - https://github.com/kubernetes-sigs/kustomize/issues/6058
+#   - https://github.com/kubernetes-sigs/kustomize/issues/6077
+#   - https://github.com/kubernetes-sigs/kustomize/issues/6079
+conda run -n rspy conda install -y -c conda-forge ansible terraform python-openstackclient passlib boto3 "kubernetes-helm<4" kubernetes-client python-kubernetes "bcrypt<5" "kustomize<5.8.0"
 
 conda run -n rspy ansible-galaxy collection install openstack.cloud amazon.aws kubernetes.core community.general


### PR DESCRIPTION
This reverts commit 56d5de17584f54fa0fb03e1de7bcdedf70e8dc28.

Revert to Kustomize 5.7 / Helm v3.

Kustomize 5.8.1 simply does not work correctly, just like 5.8.0. See this impressive list of issues:
   - https://github.com/kubernetes-sigs/kustomize/issues/6014
   - https://github.com/kubernetes-sigs/kustomize/issues/6027
   - https://github.com/kubernetes-sigs/kustomize/issues/6031
   - https://github.com/kubernetes-sigs/kustomize/issues/6058
   - https://github.com/kubernetes-sigs/kustomize/issues/6077
   - https://github.com/kubernetes-sigs/kustomize/issues/6079