### PR TITLE
CI: Trigger downstream deployments

### DIFF
--- a/.github/workflows/test-deployment-downstream.yml
+++ b/.github/workflows/test-deployment-downstream.yml
@@ -1,0 +1,54 @@
+# Copyright 2023-2026 Airbus, CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Test downstream deployments
+
+# Run workflow only for ...
+on:
+  pull_request: # pull requests
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - develop # pushes on the 'develop' branch
+  workflow_dispatch: # manual trigger
+
+jobs:
+  test-deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo: ['rs-infra-monitoring', 'rs-server-deployment', 'rs-workflow-env']
+    steps:
+      - name: Check if branch exists in ${{ matrix.repo }}
+        id: check_branch
+        env:
+          LOCAL_BRANCH: ${{ github.head_ref }}
+          TARGET_REPO: ${{ matrix.repo }}
+        run: |
+          if git ls-remote --heads "https://github.com/RS-PYTHON/${TARGET_REPO}.git" ${LOCAL_BRANCH} | grep -q ${LOCAL_BRANCH}; then
+            echo "branch_to_use=$LOCAL_BRANCH" >> $GITHUB_OUTPUT
+          else
+            echo "branch_to_use=develop" >> $GITHUB_OUTPUT
+          fi
+      - name: Trigger deployment of ${{ matrix.repo }}
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: test-deployment.yml
+          repo: RS-PYTHON/${{ matrix.repo }}
+          ref: ${{ steps.check_branch.outputs.branch_to_use }}
+          inputs: '{ "infra_core_ref": "${{ github.head_ref }}"}'
+          token: '${{ secrets.TRIGGER_WORKFLOWS }}'
+          wait-for-completion: true
+          wait-timeout-seconds: 3600


### PR DESCRIPTION
Trigger deployment tests in our downstream repositories:
- https://github.com/RS-PYTHON/rs-infra-monitoring
- https://github.com/RS-PYTHON/rs-server-deployment
- https://github.com/RS-PYTHON/rs-workflow-env

Requires these pull requests:
- https://github.com/RS-PYTHON/rs-infra-monitoring/pull/43
- https://github.com/RS-PYTHON/rs-workflow-env/pull/64
- https://github.com/RS-PYTHON/rs-server-deployment/pull/55