### PR TITLE
Revert "Update to kube-prometheus-stack 82.4.2"

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -73,9 +73,9 @@ Below are all the FOSS (Free and open-source software) used and their respective
 
 - kube-prometheus-stack
   - Custom Resource Definitions
-    - Version: 82.4.2
-    - Licence: [Apache License 2.0](https://github.com/prometheus-community/helm-charts/blob/kube-prometheus-stack-82.4.2/LICENSE)
-    - Source: <https://github.com/prometheus-community/helm-charts/tree/kube-prometheus-stack-82.4.2/charts/kube-prometheus-stack/charts/crds>
+    - Version: 58.0.0
+    - Licence: [Apache License 2.0](https://github.com/prometheus-community/helm-charts/blob/kube-prometheus-stack-58.0.0/LICENSE)
+    - Source: <https://github.com/prometheus-community/helm-charts/tree/kube-prometheus-stack-58.0.0/charts/kube-prometheus-stack/charts/crds>
     - Copyright: Copyright The Prometheus community Development Team. [Authors and Contributors](https://github.com/prometheus-community/helm-charts/graphs/contributors)
   - Helm chart: *None*
   - Container image(s) *None*

--- a/apps/00-crds-prometheus/kustomization.yaml
+++ b/apps/00-crds-prometheus/kustomization.yaml
@@ -14,16 +14,16 @@
 
 
 resources:
-- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-82.4.2/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
-- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-82.4.2/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusagents.yaml
-- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-82.4.2/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml
-- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-82.4.2/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml
-- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-82.4.2/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml
-- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-82.4.2/charts/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml
-- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-82.4.2/charts/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml
-- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-82.4.2/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
-- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-82.4.2/charts/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml
-- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-82.4.2/charts/kube-prometheus-stack/charts/crds/crds/crd-scrapeconfigs.yaml
+- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-58.0.0/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
+- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-58.0.0/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusagents.yaml
+- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-58.0.0/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml
+- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-58.0.0/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml
+- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-58.0.0/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml
+- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-58.0.0/charts/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml
+- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-58.0.0/charts/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml
+- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-58.0.0/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
+- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-58.0.0/charts/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml
+- https://raw.githubusercontent.com/prometheus-community/helm-charts/refs/tags/kube-prometheus-stack-58.0.0/charts/kube-prometheus-stack/charts/crds/crds/crd-scrapeconfigs.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:


### PR DESCRIPTION
Reverts RS-PYTHON/rs-infra-core#280

This bring an update to Prometheus 3.x which will certainly break Alloy if we don't update it as well.