### PR TITLE
RSPY-1025 - Update SVG diagram to new S1-ARD processor version

### DIFF
--- a/docs/media/architecture-k8s.svg
+++ b/docs/media/architecture-k8s.svg
@@ -1980,22 +1980,22 @@ limitations under the License.
          x="215.25285"
          y="465.82037"
          style="font-size:9.33333px;fill:#000000"
-         id="tspan11293-2">        dask[complete]==2024.5.2 \</tspan><tspan
+         id="tspan11293-2">        dask[complete]==2026.1.2 \</tspan><tspan
          sodipodi:role="line"
          x="215.25285"
          y="477.48706"
          style="font-size:9.33333px;fill:#000000"
-         id="tspan11295-6">        distributed==2024.5.2 \</tspan><tspan
+         id="tspan11295-6">        distributed==2026.1.2 \</tspan><tspan
          sodipodi:role="line"
          x="215.25285"
          y="489.15372"
          style="font-size:9.33333px;fill:#000000"
-         id="tspan11362">        eopf==2.5.9 \</tspan><tspan
+         id="tspan11362">        eopf==3.0.0 \</tspan><tspan
          sodipodi:role="line"
          x="215.25285"
          y="500.82037"
          style="font-size:9.33333px;fill:#000000"
-         id="tspan11297-6">        s1_l12_rp==0.2.1</tspan></text>
+         id="tspan11297-6">        s1_ard==1.2.0</tspan></text>
     <text
        xml:space="preserve"
        id="text11299"
@@ -2042,7 +2042,7 @@ limitations under the License.
        id="tspan4002-1-9"
        x="192.3596"
        y="304.67142"
-       style="fill-rule:nonzero;stroke:none;stroke-width:2;stroke-dasharray:8, 6;stroke-dashoffset:0;stroke-opacity:1">rs-dask-processing-s1-ard:0.2.1</tspan></text>
+       style="fill-rule:nonzero;stroke:none;stroke-width:2;stroke-dasharray:8, 6;stroke-dashoffset:0;stroke-opacity:1">rs-dask-processing-s1-ard:1.0a10</tspan></text>
   <text
      xml:space="preserve"
      style="fill:#000000;fill-rule:nonzero;stroke-width:2;stroke-dasharray:8, 6;stroke-dashoffset:0"
@@ -2053,7 +2053,7 @@ limitations under the License.
        id="tspan4002-1-9-0"
        x="246.54124"
        y="546.82861"
-       style="fill-rule:nonzero;stroke:none;stroke-width:2;stroke-dasharray:8, 6;stroke-dashoffset:0;stroke-opacity:1">rs-dask-staging:1.0a6</tspan></text>
+       style="fill-rule:nonzero;stroke:none;stroke-width:2;stroke-dasharray:8, 6;stroke-dashoffset:0;stroke-opacity:1">rs-dask-staging:1.0a10</tspan></text>
   <text
      xml:space="preserve"
      style="fill:#ff00ff;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-dasharray:8, 6;stroke-dashoffset:0;stroke-opacity:1"


### PR DESCRIPTION
Update S1-ARD to new repositories:
- https://gitlab.eopf.copernicus.eu/S1/s1-ard
- https://gitlab.eopf.copernicus.eu/S1/s1-ard-core

Pull requests:
- https://github.com/RS-PYTHON/rs-demo/pull/294
- https://github.com/RS-PYTHON/rs-client-libraries/pull/269
- https://github.com/RS-PYTHON/rs-infra-core/pull/311
- https://github.com/RS-PYTHON/rs-dpr-service/pull/105